### PR TITLE
feature: Share the rhproxy env with the engine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Where <command> is one of:
 The configuration of rhproxy can be updated as follows:
 
 - update the Insights Proxy parameters in `~/.config/rhproxy/env/rhproxy.env` 
-- you can also update the list of allowed upstream servers in `~/.config/rhproxy/env/rhproxy.servers`
+- you can also update the list of allowed upstream servers in `~/.config/rhproxy/env/redhat.servers` and `~/.config/rhproxy/env/mirror.servers`
 
 then restart the service:
 

--- a/bin/rhproxy-configure
+++ b/bin/rhproxy-configure
@@ -6,7 +6,6 @@
 #
 
 export PROXY_ENVFILE="rhproxy.env"
-export SERVERS_ENVFILE="rhproxy-servers.env"
 
 [ $# -ne 1 ] && echo "Usage: ${0} service-environment-directory" >&2 && exit 1
 
@@ -16,14 +15,6 @@ shift
 [ ! -d "${ENV_DIR}" ] && echo "Insights Proxy environment directory ${ENV_DIR} does not exist" >&2 && exit 1
 
 cd "${ENV_DIR}"
-
-#
-# Let's define the RHPROXY_SERVER_NAMES environment based on the servers list
-#
-
-echo -n "RHPROXY_SERVER_NAMES=" > "${SERVERS_ENVFILE}"
-cat rhproxy.servers | egrep -v "^#|^$|^[ \t]*$" | tr "\n" " " >> "${SERVERS_ENVFILE}"
-echo >> "${SERVERS_ENVFILE}"
 
 #
 # Let's define the resolver to use for the NGINX Server.

--- a/config/rhproxy.container
+++ b/config/rhproxy.container
@@ -10,9 +10,9 @@ ExposeHostPort=3128
 PublishPort=8443:8443
 ExposeHostPort=8443
 EnvironmentFile=%h/.config/rhproxy/env/rhproxy.env
-EnvironmentFile=%h/.config/rhproxy/env/rhproxy-servers.env
 Volume=%h/.local/share/rhproxy/certs:/opt/app-root/certs:z
 Volume=%h/.local/share/rhproxy/download:/opt/app-root/download:z
+Volume=%h/.config/rhproxy/env:/opt/app-root/rhproxy-env:z
 # Since we could write self-generated keys to the shared certs volume
 # Let's make sure we map the nginx user to the host's user.
 UserNS=keep-id:uid=1001,gid=1001

--- a/env/mirror.servers
+++ b/env/mirror.servers
@@ -1,0 +1,1 @@
+# Dnf/Yum Mirror Servers

--- a/env/redhat.servers
+++ b/env/redhat.servers
@@ -14,5 +14,4 @@ sso.redhat.com
 
 # Support RedHat Dnf/Yum Installs
 cdn.redhat.com
-
-# Non RedHat Servers
+*.fedoraproject.org

--- a/rhproxy.spec
+++ b/rhproxy.spec
@@ -1,5 +1,5 @@
 %global base_version 1.3
-%global patch_version 0
+%global patch_version 1
 
 Name:           rhproxy
 Version:        %{base_version}.%{patch_version}
@@ -45,10 +45,16 @@ sed -i 's/{{RHPROXY_ENGINE_RELEASE_TAG}}/%{base_version}/' %{buildroot}/%{_datad
 %{_datadir}/%{name}/bin/rhproxy-configure
 %{_datadir}/%{name}/config/rhproxy.container
 %{_datadir}/%{name}/env/rhproxy.env
-%{_datadir}/%{name}/env/rhproxy.servers
+%{_datadir}/%{name}/env/redhat.servers
+%{_datadir}/%{name}/env/mirror.servers
 %{_datadir}/%{name}/download/bin/configure-client.sh.template
 
 %changelog
+* Tue Sep 18 2024 Alberto Bellotti <abellott@redhat.com> - 1.3.1
+- Sharing rhproxy env directory with the rhproxy-engine
+- No longer the need to create an env variable for the list of servers
+- Now supporting redhat.servers and mirror.servers
+
 * Tue Sep 17 2024 Alberto Bellotti <abellott@redhat.com> - 1.3.0
 - Moving to major.minor.patch version of the RPM.
 - Moving to major.minor released versions of the container engine.


### PR DESCRIPTION
- Sharing the rhproxy service env directory witih the container via a volume mount
- Removing the need to create the rhproxy-servers.env file from the rhproxy.servers file.
- Renaming rhproxy.servers and support instead the redhat.servers and mirror.servers files.
- New rhproxy-engine knows how to parse the servers file and create the server_name directives for NGINX.