### PR TITLE
feature: adding support for /etc/redhat/insights.toml

### DIFF
--- a/download/bin/configure-client.sh.template
+++ b/download/bin/configure-client.sh.template
@@ -84,21 +84,18 @@ function create_insights_conf {
 # Red Hat Insights Configuration File
 
 [insights-proxy]
-
 # An http proxy server to use for communicating with Insights
-host =
+host = ""
 
 # The port for the insights proxy
-port =
+port = 0
 
 # The scheme to use for the insights proxy
-scheme = http
+scheme = "http"
 
-# The user name for authenticating to the insights proxy (optional)
-user =
-
-# The password for authenticating to the insights proxy (optional)
-password =
+# The user name and password for authenticating to the insights proxy (optional)
+user = ""
+password = ""
 !END!
     chmod 644 "${INSIGHTS_CONF}"
   fi
@@ -144,11 +141,11 @@ Environment=HTTPS_PROXY=http://${PROXY_HOST}:${PROXY_PORT}
   TMP_CONF="$(mktemp)"
   sed -n '0,/^\[insights-proxy\]/p' "${INSIGHTS_CONF}" > "${TMP_CONF}"
   if sed '0,/^\[insights-proxy\]/d' "${INSIGHTS_CONF}" |
-    sed -e "0,/^host =.*$/ s//host = ${PROXY_HOST}/" \
+    sed -e "0,/^host =.*$/ s//host = \"${PROXY_HOST}\"/" \
         -e "0,/^port =.*$/ s//port = ${PROXY_PORT}/" \
-        -e "0,/^scheme =.*$/ s//scheme = http/" \
-        -e "0,/^user =.*$/ s//user =/" \
-        -e "0,/^password =.*$/ s//password =/" >> "${TMP_CONF}"; then
+        -e "0,/^scheme =.*$/ s//scheme = \"http\"/" \
+        -e "0,/^user =.*$/ s//user = \"\"/" \
+        -e "0,/^password =.*$/ s//password = \"\"/" >> "${TMP_CONF}"; then
     cp "${TMP_CONF}" "${INSIGHTS_CONF}"
   fi
   rm -f "${TMP_CONF}"
@@ -172,8 +169,8 @@ elif [ "${SUBCMD}" = "--unconfigure" ]; then
     TMP_CONF="$(mktemp)"
     sed -n '0,/^\[insights-proxy\]/p' "${INSIGHTS_CONF}" > "${TMP_CONF}"
     if sed '0,/^\[insights-proxy\]/d' "${INSIGHTS_CONF}" |
-      sed -e "0,/^host =.*$/ s//host =/" \
-          -e "0,/^port =.*$/ s//port =/" >> "${TMP_CONF}"; then
+      sed -e "0,/^host =.*$/ s//host = \"\"/" \
+          -e "0,/^port =.*$/ s//port = 0/" >> "${TMP_CONF}"; then
       cp "${TMP_CONF}" "${INSIGHTS_CONF}"
     fi
     rm -f "${TMP_CONF}"

--- a/download/bin/configure-client.sh.template
+++ b/download/bin/configure-client.sh.template
@@ -71,7 +71,7 @@ allow rhcd_t squid_port_t:tcp_socket name_connect;
 }
 
 export INSIGHTS_CONF_DIR="/etc/redhat"
-export INSIGHTS_CONF="${INSIGHTS_CONF_DIR}/insights.conf"
+export INSIGHTS_CONF="${INSIGHTS_CONF_DIR}/insights.toml"
 export RHSM_CONF="/etc/rhsm/rhsm.conf"
 export RHCD_OVERRIDE_DIR="/etc/systemd/system/rhcd.service.d"
 
@@ -83,22 +83,22 @@ function create_insights_conf {
     cat - > "${INSIGHTS_CONF}" <<!END!
 # Red Hat Insights Configuration File
 
-[global]
+[insights-proxy]
 
 # An http proxy server to use for communicating with Insights
-rhproxy_host =
+host =
 
 # The port for the insights proxy
-rhproxy_port =
+port =
 
 # The scheme to use for the insights proxy
-rhproxy_scheme = http
+scheme = http
 
 # The user name for authenticating to the insights proxy (optional)
-rhproxy_user =
+user =
 
 # The password for authenticating to the insights proxy (optional)
-rhproxy_password =
+password =
 !END!
   fi
 }
@@ -140,11 +140,13 @@ Environment=HTTPS_PROXY=http://${PROXY_HOST}:${PROXY_PORT}
   create_insights_conf
   echo "Configuring ${INSIGHTS_CONF} rhproxy for ${PROXY_HOST}:${PROXY_PORT} ..."
   cp "${INSIGHTS_CONF}" "${INSIGHTS_CONF}.saved"
-  sed -i  -e "s/^rhproxy_host =.*$/rhproxy_host = ${PROXY_HOST}/" \
-          -e "s/^rhproxy_port =.*$/rhproxy_port = ${PROXY_PORT}/" \
-          -e "s/^rhproxy_scheme =.*$/rhproxy_port = http/" \
-          -e "s/^rhproxy_user =.*$/rhproxy_user =/" \
-          -e "s/^rhproxy_password =.*$/rhproxy_password =/" "${INSIGHTS_CONF}"
+  sed -n '0,/^\[insights-proxy\]/p' "${INSIGHTS_CONF}.saved" > "${INSIGHTS_CONF}"
+  sed    '0,/^\[insights-proxy\]/d' "${INSIGHTS_CONF}.saved" |
+    sed -e "0,/^host =.*$/ s//host = ${PROXY_HOST}/" \
+        -e "0,/^port =.*$/ s//port = ${PROXY_PORT}/" \
+        -e "0,/^scheme =.*$/ s//scheme = http/" \
+        -e "0,/^user =.*$/ s//user =/" \
+        -e "0,/^password =.*$/ s//password =/" >> "${INSIGHTS_CONF}"
 
   install_rhcd_selinux_policy
   restart_services
@@ -162,8 +164,10 @@ elif [ "${SUBCMD}" = "--unconfigure" ]; then
   if [ -f "${INSIGHTS_CONF}" ]; then
     echo "Un-Configuring rhproxy from ${INSIGHTS_CONF} ..."
     cp "${INSIGHTS_CONF}" "${INSIGHTS_CONF}.saved"
-    sed -i  -e "s/^rhproxy_host =.*$/rhproxy_host =/" \
-            -e "s/^rhproxy_port =.*$/rhproxy_port =/" "${INSIGHTS_CONF}"
+    sed -n '0,/^\[insights-proxy\]/p' "${INSIGHTS_CONF}.saved" > "${INSIGHTS_CONF}"
+    sed    '0,/^\[insights-proxy\]/d' "${INSIGHTS_CONF}.saved" |
+      sed -e "0,/^host =.*$/ s//host =/" \
+          -e "0,/^port =.*$/ s//port =/" >> "${INSIGHTS_CONF}"
   fi
 
   # Remove the override for the RHC Daemon

--- a/download/bin/configure-client.sh.template
+++ b/download/bin/configure-client.sh.template
@@ -100,6 +100,7 @@ user =
 # The password for authenticating to the insights proxy (optional)
 password =
 !END!
+    chmod 644 "${INSIGHTS_CONF}"
   fi
 }
 
@@ -140,13 +141,17 @@ Environment=HTTPS_PROXY=http://${PROXY_HOST}:${PROXY_PORT}
   create_insights_conf
   echo "Configuring ${INSIGHTS_CONF} rhproxy for ${PROXY_HOST}:${PROXY_PORT} ..."
   cp "${INSIGHTS_CONF}" "${INSIGHTS_CONF}.saved"
-  sed -n '0,/^\[insights-proxy\]/p' "${INSIGHTS_CONF}.saved" > "${INSIGHTS_CONF}"
-  sed    '0,/^\[insights-proxy\]/d' "${INSIGHTS_CONF}.saved" |
+  TMP_CONF="$(mktemp)"
+  sed -n '0,/^\[insights-proxy\]/p' "${INSIGHTS_CONF}" > "${TMP_CONF}"
+  if sed '0,/^\[insights-proxy\]/d' "${INSIGHTS_CONF}" |
     sed -e "0,/^host =.*$/ s//host = ${PROXY_HOST}/" \
         -e "0,/^port =.*$/ s//port = ${PROXY_PORT}/" \
         -e "0,/^scheme =.*$/ s//scheme = http/" \
         -e "0,/^user =.*$/ s//user =/" \
-        -e "0,/^password =.*$/ s//password =/" >> "${INSIGHTS_CONF}"
+        -e "0,/^password =.*$/ s//password =/" >> "${TMP_CONF}"; then
+    cp "${TMP_CONF}" "${INSIGHTS_CONF}"
+  fi
+  rm -f "${TMP_CONF}"
 
   install_rhcd_selinux_policy
   restart_services
@@ -164,10 +169,14 @@ elif [ "${SUBCMD}" = "--unconfigure" ]; then
   if [ -f "${INSIGHTS_CONF}" ]; then
     echo "Un-Configuring rhproxy from ${INSIGHTS_CONF} ..."
     cp "${INSIGHTS_CONF}" "${INSIGHTS_CONF}.saved"
-    sed -n '0,/^\[insights-proxy\]/p' "${INSIGHTS_CONF}.saved" > "${INSIGHTS_CONF}"
-    sed    '0,/^\[insights-proxy\]/d' "${INSIGHTS_CONF}.saved" |
+    TMP_CONF="$(mktemp)"
+    sed -n '0,/^\[insights-proxy\]/p' "${INSIGHTS_CONF}" > "${TMP_CONF}"
+    if sed '0,/^\[insights-proxy\]/d' "${INSIGHTS_CONF}" |
       sed -e "0,/^host =.*$/ s//host =/" \
-          -e "0,/^port =.*$/ s//port =/" >> "${INSIGHTS_CONF}"
+          -e "0,/^port =.*$/ s//port =/" >> "${TMP_CONF}"; then
+      cp "${TMP_CONF}" "${INSIGHTS_CONF}"
+    fi
+    rm -f "${TMP_CONF}"
   fi
 
   # Remove the override for the RHC Daemon

--- a/download/bin/configure-client.sh.template
+++ b/download/bin/configure-client.sh.template
@@ -70,8 +70,39 @@ allow rhcd_t squid_port_t:tcp_socket name_connect;
   /usr/sbin/semodule -X 300 -i "${SEL_BUILD}/rhcd-proxy.pp"
 }
 
+export INSIGHTS_CONF_DIR="/etc/redhat"
+export INSIGHTS_CONF="${INSIGHTS_CONF_DIR}/insights.conf"
 export RHSM_CONF="/etc/rhsm/rhsm.conf"
 export RHCD_OVERRIDE_DIR="/etc/systemd/system/rhcd.service.d"
+
+
+function create_insights_conf {
+  # Let's define the Insights config file if not there already
+  if [ ! -f "${INSIGHTS_CONF}" ]; then
+    mkdir -p "${INSIGHTS_CONF_DIR}"
+    cat - > "${INSIGHTS_CONF}" <<!END!
+# Red Hat Insights Configuration File
+
+[global]
+
+# An http proxy server to use for communicating with Insights
+rhproxy_host =
+
+# The port for the insights proxy
+rhproxy_port =
+
+# The scheme to use for the insights proxy
+rhproxy_scheme = http
+
+# The user name for authenticating to the insights proxy (optional)
+rhproxy_user =
+
+# The password for authenticating to the insights proxy (optional)
+rhproxy_password =
+!END!
+  fi
+}
+
 
 #---------------- Configure ---------------
 if [ "${SUBCMD}" = "--configure" ]; then
@@ -106,6 +137,15 @@ Environment=HTTP_PROXY=http://${PROXY_HOST}:${PROXY_PORT}
 Environment=HTTPS_PROXY=http://${PROXY_HOST}:${PROXY_PORT}
 !END!
 
+  create_insights_conf
+  echo "Configuring ${INSIGHTS_CONF} rhproxy for ${PROXY_HOST}:${PROXY_PORT} ..."
+  cp "${INSIGHTS_CONF}" "${INSIGHTS_CONF}.saved"
+  sed -i  -e "s/^rhproxy_host =.*$/rhproxy_host = ${PROXY_HOST}/" \
+          -e "s/^rhproxy_port =.*$/rhproxy_port = ${PROXY_PORT}/" \
+          -e "s/^rhproxy_scheme =.*$/rhproxy_port = http/" \
+          -e "s/^rhproxy_user =.*$/rhproxy_user =/" \
+          -e "s/^rhproxy_password =.*$/rhproxy_password =/" "${INSIGHTS_CONF}"
+
   install_rhcd_selinux_policy
   restart_services
 
@@ -118,6 +158,13 @@ elif [ "${SUBCMD}" = "--unconfigure" ]; then
   cp "${RHSM_CONF}" "${RHSM_CONF}.saved"
   sed -i  -e "s/^proxy_hostname =.*$/proxy_hostname =/" \
           -e "s/^proxy_port =.*$/proxy_port =-1/" "${RHSM_CONF}"
+
+  if [ -f "${INSIGHTS_CONF}" ]; then
+    echo "Un-Configuring rhproxy from ${INSIGHTS_CONF} ..."
+    cp "${INSIGHTS_CONF}" "${INSIGHTS_CONF}.saved"
+    sed -i  -e "s/^rhproxy_host =.*$/rhproxy_host =/" \
+            -e "s/^rhproxy_port =.*$/rhproxy_port =/" "${INSIGHTS_CONF}"
+  fi
 
   # Remove the override for the RHC Daemon
   rm -f "${RHCD_OVERRIDE_DIR}/override.conf"

--- a/download/bin/configure-client.sh.template
+++ b/download/bin/configure-client.sh.template
@@ -138,17 +138,12 @@ Environment=HTTPS_PROXY=http://${PROXY_HOST}:${PROXY_PORT}
   create_insights_conf
   echo "Configuring ${INSIGHTS_CONF} rhproxy for ${PROXY_HOST}:${PROXY_PORT} ..."
   cp "${INSIGHTS_CONF}" "${INSIGHTS_CONF}.saved"
-  TMP_CONF="$(mktemp)"
-  sed -n '0,/^\[insights-proxy\]/p' "${INSIGHTS_CONF}" > "${TMP_CONF}"
-  if sed '0,/^\[insights-proxy\]/d' "${INSIGHTS_CONF}" |
-    sed -e "0,/^host =.*$/ s//host = \"${PROXY_HOST}\"/" \
-        -e "0,/^port =.*$/ s//port = ${PROXY_PORT}/" \
-        -e "0,/^scheme =.*$/ s//scheme = \"http\"/" \
-        -e "0,/^user =.*$/ s//user = \"\"/" \
-        -e "0,/^password =.*$/ s//password = \"\"/" >> "${TMP_CONF}"; then
-    cp "${TMP_CONF}" "${INSIGHTS_CONF}"
-  fi
-  rm -f "${TMP_CONF}"
+  SECTION='/\[insights-proxy\]/,/^\[/'
+  sed -i -e "${SECTION} s/^host =.*$/host = \"${PROXY_HOST}\"/" \
+         -e "${SECTION} s/^port =.*$/port = ${PROXY_PORT}/" \
+         -e "${SECTION} s/^scheme =.*$/scheme = \"http\"/" \
+         -e "${SECTION} s/^user =.*$/user = \"\"/" \
+         -e "${SECTION} s/^password =.*$/password = \"\"/" "${INSIGHTS_CONF}"
 
   install_rhcd_selinux_policy
   restart_services
@@ -166,14 +161,9 @@ elif [ "${SUBCMD}" = "--unconfigure" ]; then
   if [ -f "${INSIGHTS_CONF}" ]; then
     echo "Un-Configuring rhproxy from ${INSIGHTS_CONF} ..."
     cp "${INSIGHTS_CONF}" "${INSIGHTS_CONF}.saved"
-    TMP_CONF="$(mktemp)"
-    sed -n '0,/^\[insights-proxy\]/p' "${INSIGHTS_CONF}" > "${TMP_CONF}"
-    if sed '0,/^\[insights-proxy\]/d' "${INSIGHTS_CONF}" |
-      sed -e "0,/^host =.*$/ s//host = \"\"/" \
-          -e "0,/^port =.*$/ s//port = 0/" >> "${TMP_CONF}"; then
-      cp "${TMP_CONF}" "${INSIGHTS_CONF}"
-    fi
-    rm -f "${TMP_CONF}"
+    SECTION='/\[insights-proxy\]/,/^\[/'
+    sed -i -e "${SECTION} s/^host =.*$/host = \"\"/"  \
+           -e "${SECTION} s/^port =.*$/port = 0/" "${INSIGHTS_CONF}"
   fi
 
   # Remove the override for the RHC Daemon


### PR DESCRIPTION
- Create the file if not initially there from the client
- Configure and Unconfigure the rhproxy entries upon configuring and unconfiguring the client for the insights proxy.

For: https://issues.redhat.com/projects/IPP/issues/IPP-13

