### PR TITLE
Bumping to 1.3.2

### DIFF
--- a/rhproxy.spec
+++ b/rhproxy.spec
@@ -1,5 +1,5 @@
 %global base_version 1.3
-%global patch_version 1
+%global patch_version 2
 
 Name:           rhproxy
 Version:        %{base_version}.%{patch_version}
@@ -50,6 +50,9 @@ sed -i 's/{{RHPROXY_ENGINE_RELEASE_TAG}}/%{base_version}/' %{buildroot}/%{_datad
 %{_datadir}/%{name}/download/bin/configure-client.sh.template
 
 %changelog
+* Thu Oct 17 2024 Alberto Bellotti <abellott@redhat.com> - 1.3.2
+- Now using URL based Source in the RPM spec
+
 * Wed Sep 18 2024 Alberto Bellotti <abellott@redhat.com> - 1.3.1
 - Sharing rhproxy env directory with the rhproxy-engine
 - No longer the need to create an env variable for the list of servers


### PR DESCRIPTION
- Bumping to 1.3.2
- Now using URL specification of the Source in the RPM spec
