### PR TITLE
Enable user lingering and patch version requirement for the engine

### DIFF
--- a/bin/rhproxy
+++ b/bin/rhproxy
@@ -106,6 +106,9 @@ if [ "${COMMAND}" == "install" ]; then
   echo "Generate the ${RHPROXY_NAME} service ..."
   systemctl --user daemon-reload
 
+  echo "Enabling Lingering for user ${USER} ..."
+  loginctl enable-linger "${USER}"
+
   update_download_files
 
   echo "${RHPROXY_NAME} Installed."
@@ -132,6 +135,9 @@ if [ "${COMMAND}" == "uninstall" ]; then
     echo "   Removing ${DOWNLOAD_SHARE_PATH} ..."
     rm -rf "${DOWNLOAD_SHARE_PATH}"
   fi
+
+  echo "Disabling Lingering for user ${USER} ..."
+  loginctl disable-linger "${USER}"
 
   echo "${RHPROXY_NAME} Uninstalled."
   exit 0

--- a/rhproxy.spec
+++ b/rhproxy.spec
@@ -1,5 +1,6 @@
 %global base_version 1.3
 %global patch_version 4
+%global engine_version 1.3.2
 
 Name:           rhproxy
 Version:        %{base_version}.%{patch_version}
@@ -37,7 +38,7 @@ mkdir -p %{buildroot}/%{_datadir}/%{name}/download/bin
 cp download/bin/*.template %{buildroot}/%{_datadir}/%{name}/download/bin/
 
 # Let's make sure we pick the major.minor released version of the engine
-sed -i 's/{{RHPROXY_ENGINE_RELEASE_TAG}}/%{base_version}/' %{buildroot}/%{_datadir}/%{name}/config/rhproxy.container
+sed -i 's/{{RHPROXY_ENGINE_RELEASE_TAG}}/%{engine_version}/' %{buildroot}/%{_datadir}/%{name}/config/rhproxy.container
 
 %files
 %license LICENSE


### PR DESCRIPTION

- Enabling user lingering upon rhproxy installs
- Disabling user lingering upon rhproxy uninstalls
- Updated the RPM spec so it requires a specific version of the rhproxy nginx container and not just the base x.y version.

Solves: Issue https://github.com/RedHatInsights/rhproxy/issues/16
