### PR TITLE
Bumping rhproxy to 1.3.5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint Insights Proxy (rhproxy) Quadlet Installer
+name: Lint Insights proxy (rhproxy) Quadlet Installer
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Installing Insights Proxy
+# Installing Insights proxy
 
 ### Using the official RPM
 
-Using the `rhproxy` service controller, ***all commands*** for installing and interacting with Insights Proxy should be executed as a *regular non-root* user. 
+Using the `rhproxy` service controller, ***all commands*** for installing and interacting with Insights proxy should be executed as a *regular non-root* user.
 
 To use the service controller to install and manage the rhproxy service, first install the controller:
 
@@ -52,7 +52,7 @@ Required before starting the rhproxy service for pulling down the
 service image from Quay.io:
 
 ```
-$ podman login quay.io  
+$ podman login quay.io
 ```
 
 
@@ -69,23 +69,23 @@ $ rhproxy status
 To allow external access to the Insights proxy, run the following commands:
 
 ```sh
-# sudo firewall-cmd --permanent --add-port=3128/tcp 
+# sudo firewall-cmd --permanent --add-port=3128/tcp
 # sudo firewall-cmd --permanent --add-port=8443/tcp
 # sudo firewall-cmd --reload
 ```
 
 A few seconds later, you may proxy-forward Red-Hat Insights traffic to http://\<server-hosting-the-proxy\>:3128
 
-When running the Insights Proxy, a self-signed certificate is created for accessing any resources served by the proxy 
+When running the Insights proxy, a self-signed certificate is created for accessing any resources served by the proxy
 nd is stored in the host's `~/.local/share/rhproxy/certs/` directory. You may provide your own
-HTTPS certificate and key in this location before starting the Insights Proxy:
+HTTPS certificate and key in this location before starting the Insights proxy:
 
 - `~/.local/share/rhproxy/certs/rhproxy.crt`
 - `~/.local/share/rhproxy/certs/rhproxy.key`
 
-The web server part of the Insights Proxy can be accessed at https://\<server-hosting-the-proxy\>:8443
+The web server part of the Insights proxy can be accessed at https://\<server-hosting-the-proxy\>:8443
 
-The download content area for the Insights Proxy web server is located in the following location:
+The download content area for the Insights proxy web server is located in the following location:
 
 - `~/.local/share/rhproxy/download/`
 
@@ -95,14 +95,14 @@ The usage of the rhproxy service controller is included here below:
 Usage: rhproxy [-v | --verbose] <command>
 
 Where <command> is one of:
-  install           - Install Insights Proxy
-  uninstall [-f]    - Uninstall Insights Proxy
+  install           - Install Insights proxy
+  uninstall [-f]    - Uninstall Insights proxy
                       specify -f to force remove the certs and download data
 
-  start             - Start the Insights Proxy Service
-  stop              - Stop the Insights Proxy Service
-  restart           - Re-start the Insights Proxy Service
-  status            - Display Status of the Insights Proxy Service
+  start             - Start the Insights proxy Service
+  stop              - Stop the Insights proxy Service
+  restart           - Re-start the Insights proxy Service
+  status            - Display Status of the Insights proxy Service
 
   update            - Update download files
 ```
@@ -119,7 +119,7 @@ Where <command> is one of:
 
 The configuration of rhproxy can be updated as follows:
 
-- Update the Insights Proxy parameters in `~/.config/rhproxy/env/rhproxy.env`
+- Update the Insights proxy parameters in `~/.config/rhproxy/env/rhproxy.env`
 - Provide optional mirror servers in the following file:
   - `~/.config/rhproxy/env/mirror.servers`
 

--- a/bin/rhproxy
+++ b/bin/rhproxy
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# Insights Proxy Service
+# Insights proxy Service
 #
 export VERBOSE="n"
-RHPROXY_NAME="Insights Proxy"
+RHPROXY_NAME="Insights proxy"
 RHPROXY_SERVICE="rhproxy"
 RHPROXY_PKG_ROOT="${RHPROXY_PKG_ROOT:-/usr/share/${RHPROXY_SERVICE}}"
 

--- a/bin/rhproxy-configure
+++ b/bin/rhproxy-configure
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-# Insights Proxy Configuration.
+# Insights proxy Configuration.
 #
-# Customize/Update the service environment before starting up the NGINX Proxy Server.
+# Customize/Update the service environment before starting up the NGINX proxy Server.
 #
 
 export PROXY_ENVFILE="rhproxy.env"
@@ -12,7 +12,7 @@ export PROXY_ENVFILE="rhproxy.env"
 export ENV_DIR="${1}"
 shift
 
-[ ! -d "${ENV_DIR}" ] && echo "Insights Proxy environment directory ${ENV_DIR} does not exist" >&2 && exit 1
+[ ! -d "${ENV_DIR}" ] && echo "Insights proxy environment directory ${ENV_DIR} does not exist" >&2 && exit 1
 
 cd "${ENV_DIR}" || exit 1
 

--- a/config/rhproxy.container
+++ b/config/rhproxy.container
@@ -1,5 +1,5 @@
 [Unit]
-Description=Red Hat Insights Proxy
+Description=Red Hat Insights proxy
 Requires=podman.socket
 
 [Container]

--- a/download/bin/configure-client.sh.template
+++ b/download/bin/configure-client.sh.template
@@ -2,7 +2,7 @@
 
 #
 # Script to configure (or unconfigure) a client for communicating
-# to Insights via the Insights Proxy
+# to Insights via the Insights proxy
 #
 
 # Next line updated via envsubst
@@ -75,7 +75,7 @@ export RHCD_OVERRIDE_DIR="/etc/systemd/system/rhcd.service.d"
 
 #---------------- Configure ---------------
 if [ "${SUBCMD}" = "--configure" ]; then
-  # Configure the Insights Client and RHC to communicate via the Insights Proxy
+  # Configure the Insights Client and RHC to communicate via the Insights proxy
 
   # Must specify a proxy host
   [ ! "${1}" == "--proxy-host" ] && echo "Must specify a --proxy-host option" && exit 1
@@ -111,7 +111,7 @@ Environment=HTTPS_PROXY=http://${PROXY_HOST}:${PROXY_PORT}
 
 #---------------- Unconfigure ---------------
 elif [ "${SUBCMD}" = "--unconfigure" ]; then
-  # Update the Insights Client and RHC to stop using the Insights Proxy
+  # Update the Insights Client and RHC to stop using the Insights proxy
 
   echo "Un-Configuring insights-client/rhsm/rhc/rhcd from proxying to Insights ..."
   # Remove the proxy definition from the rhsm.conf file.

--- a/env/epel.servers
+++ b/env/epel.servers
@@ -1,6 +1,6 @@
 # Dnf/Yum EPEL Servers
-# Updated:  2024-10-24
-# Count:    317
+# Updated:  2024-11-01
+# Count:    319
 #
 # Warning: Any updates to this file are lost when rhproxy is updated.
 abqix.mm.fcix.net
@@ -101,6 +101,7 @@ hkg.mirror.rackspace.com
 iad.mirror.rackspace.com
 ima.mm.fcix.net
 in.mirrors.cicku.me
+ipng.mm.fcix.net
 irltoolkit.mm.fcix.net
 it1.mirror.vhosting-it.com
 it2.mirror.vhosting-it.com
@@ -109,11 +110,13 @@ jp.mirrors.cicku.me
 kr.mirrors.cicku.me
 la-mirrors.evowise.com
 lchs.mm.fcix.net
+lesnet.mm.fcix.net
 level66.mm.fcix.net
 linux-mirrors.fnal.gov
 linux.domainesia.com
 linux.mirrors.es.net
 linuxsoft.cern.ch
+lolhost.mm.fcix.net
 mirror-icn.yuki.net.uk
 mirror-nrt.yuki.net.uk
 mirror.01link.hk
@@ -126,7 +129,6 @@ mirror.airenetworks.es
 mirror.alwyzon.net
 mirror.ams-1.serverforge.org
 mirror.bahnhof.net
-mirror.bytemark.co.uk
 mirror.cedia.org.ec
 mirror.centos.ikoula.com
 mirror.cherryservers.com
@@ -229,12 +231,12 @@ mirror2.totbb.net
 mirrorepel.math.princeton.edu
 mirroronet.pl
 mirrors.20i.com
-mirrors.bangmodhosting.com
 mirrors.bestthaihost.com
 mirrors.cat.pdx.edu
 mirrors.chroot.ro
 mirrors.coreix.net
 mirrors.dotsrc.org
+mirrors.fibianet.dk
 mirrors.glesys.net
 mirrors.hosterion.ro
 mirrors.hostico.ro
@@ -252,7 +254,6 @@ mirrors.netix.net
 mirrors.neusoft.edu.cn
 mirrors.nic.cz
 mirrors.nxthost.com
-mirrors.piconets.webwerks.in
 mirrors.powernet.com.ru.
 mirrors.ptisp.pt
 mirrors.qlu.edu.cn
@@ -306,6 +307,7 @@ sg.mirrors.cicku.me
 sg.ssimn.org
 sjc.mirror.rackspace.com
 southfront.mm.fcix.net
+stix.mm.fcix.net
 stl.us.ssimn.org
 syd.mirror.rackspace.com
 tw.mirrors.cicku.me

--- a/rhproxy.spec
+++ b/rhproxy.spec
@@ -1,6 +1,6 @@
 %global base_version 1.3
-%global patch_version 4
-%global engine_version 1.3.2
+%global patch_version 5
+%global engine_version 1.3.3
 
 Name:           rhproxy
 Version:        %{base_version}.%{patch_version}

--- a/rhproxy.spec
+++ b/rhproxy.spec
@@ -5,7 +5,7 @@
 Name:           rhproxy
 Version:        %{base_version}.%{patch_version}
 Release:        1%{?dist}
-Summary:        Insights Proxy Service v%{version}
+Summary:        Insights proxy Service v%{version}
 
 License:        GPLv3
 URL:            https://github.com/RedHatInsights/rhproxy
@@ -17,9 +17,9 @@ Requires:       bash
 Requires:       podman >= 4.9.4
 
 %description
-This RPM installs the Insights Proxy Service on the System.
+This RPM installs the Insights proxy Service on the System.
 The rhproxy service controller installs and manages
-the Insights Proxy via a systemd quadlet service.
+the Insights proxy via a systemd quadlet service.
 
 %prep
 %autosetup -n %{name}-%{version}


### PR DESCRIPTION
- Bumping rhproxy RPM to 1.3.5
- Using the rhproxy Engine 1.3.3 which now includes the NGINX and http proxy connect module sources for security checks
- Renamed all Insights Proxy to Insights proxy
- Update to the latest list of EPEL servers
