### PR TITLE
Bumping release to 1.3.7

### DIFF
--- a/config/rhproxy.container
+++ b/config/rhproxy.container
@@ -4,7 +4,7 @@ Requires=podman.socket
 
 [Container]
 ContainerName=rhproxy
-Image=quay.io/abellott/rhproxy-engine:{{RHPROXY_ENGINE_RELEASE_TAG}}
+Image=quay.io/insights_proxy/rhproxy-engine:{{RHPROXY_ENGINE_RELEASE_TAG}}
 PublishPort=3128:3128
 ExposeHostPort=3128
 PublishPort=8443:8443

--- a/env/epel.servers
+++ b/env/epel.servers
@@ -1,6 +1,6 @@
 # Dnf/Yum EPEL Servers
-# Updated:        2024-11-05
-# Count:          313
+# Updated:        2024-11-12
+# Count:          307
 # Versions:       4, 5, 6, 7, 8, 9, 10
 # Architectures:  aarch64, armhfp, i386, ppc64, ppc64le, s390x, x86_64
 #
@@ -40,14 +40,12 @@ epel.hysing.is
 epel.ip-connect.info
 epel.mirror.constant.com
 epel.mirror.digitalpacific.com.au
-epel.mirror.liquidtelecom.com
 epel.mirror.omnilance.com
 epel.mirror.shastacoe.net
 epel.sg.ssimn.org
 epel.srv.magticom.ge
 epel.stl.us.ssimn.org
 epel.uni-sofia.bg
-es-mirrors.evowise.com
 es.mirrors.cicku.me
 espejito.fder.edu.uy
 eu.edge.kernel.org
@@ -84,7 +82,6 @@ ftp.fi.muni.cz
 ftp.halifax.rwth-aachen.de
 ftp.icm.edu.pl
 ftp.kaist.ac.kr
-ftp.kddilabs.jp
 ftp.nluug.nl
 ftp.nsc.ru
 ftp.ntua.gr
@@ -112,7 +109,6 @@ it2.mirror.vhosting-it.com
 ix-denver.mm.fcix.net
 jp.mirrors.cicku.me
 kr.mirrors.cicku.me
-la-mirrors.evowise.com
 lchs.mm.fcix.net
 lesnet.mm.fcix.net
 level66.mm.fcix.net
@@ -211,6 +207,7 @@ mirror.sabay.com.kh
 mirror.servaxnet.com
 mirror.sfo12.us.leaseweb.net
 mirror.siena.edu
+mirror.siwoo.org
 mirror.steadfastnet.com
 mirror.szerverem.hu
 mirror.team-cymru.com
@@ -279,7 +276,6 @@ nl.mirrors.cicku.me
 nnenix.mm.fcix.net
 nocix.mm.fcix.net
 nullroute.mm.fcix.net
-ny-mirrors.evowise.com
 ohioix.mm.fcix.net
 opencolo.mm.fcix.net
 ord.mirror.rackspace.com
@@ -308,12 +304,10 @@ stix.mm.fcix.net
 syd.mirror.rackspace.com
 tw.mirrors.cicku.me
 ucmirror.canterbury.ac.nz
-uk-mirrors.evowise.com
 us.mirrors.cicku.me
 uvermont.mm.fcix.net
 veronanetworks.mm.fcix.net
 volico.mm.fcix.net
-www.ftp.ne.jp
 www.gtlib.gatech.edu
 www.nic.funet.fi
 za.mirrors.cicku.me

--- a/rhproxy.spec
+++ b/rhproxy.spec
@@ -1,6 +1,6 @@
 %global base_version 1.3
-%global patch_version 6
-%global engine_version 1.3.4
+%global patch_version 7
+%global engine_version 1.3.6
 
 Name:           rhproxy
 Version:        %{base_version}.%{patch_version}
@@ -53,6 +53,10 @@ sed -i 's/{{RHPROXY_ENGINE_RELEASE_TAG}}/%{engine_version}/' %{buildroot}/%{_dat
 %{_datadir}/%{name}/download/bin/configure-client.sh.template
 
 %changelog
+* Tue Nov 12 2024 Alberto Bellotti <abellott@redhat.com> - 1.3.7
+- Using the 1.3.6 Konflux built rhproxy engine
+- Pulling rhproxy-engine from the quay.io/insights_proxy/rhproxy-engine repo
+
 * Tue Nov 05 2024 Alberto Bellotti <abellott@redhat.com> - 1.3.6
 - Using 1.3.4 rhproxy engine which includes cleanup of the source
 - Default DNS Server to 1.1.1.1 to be consistent with the rhproxy engine


### PR DESCRIPTION
- Bumping to 1.3.7
- Using the 1.3.6 Konflux built rhproxy engine
- Pulling rhproxy-engine from the quay.io/insights_proxy/rhproxy-engine repo
- Updated epel.servers list