### PR TITLE
Adding Fedora 41 builds to upstream

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,10 +13,10 @@ jobs:
       - rhel-9-x86_64
       - rhel-9-aarch64
       # and latest fedora releases
-      - fedora-39-x86_64
-      - fedora-39-aarch64
       - fedora-40-x86_64
       - fedora-40-aarch64
+      - fedora-41-x86_64
+      - fedora-41-aarch64
 
   - job: copr_build
     trigger: commit

--- a/env/epel.servers
+++ b/env/epel.servers
@@ -1,5 +1,5 @@
 # Dnf/Yum EPEL Servers
-# Updated:        2024-11-12
+# Updated:        2024-11-26
 # Count:          307
 # Versions:       4, 5, 6, 7, 8, 9, 10
 # Architectures:  aarch64, armhfp, i386, ppc64, ppc64le, s390x, x86_64
@@ -23,6 +23,7 @@ ch.mirrors.cicku.me
 codingflyboy.mm.fcix.net
 cofractal-ewr.mm.fcix.net
 cofractal-sea.mm.fcix.net
+coresite-atl.mm.fcix.net
 creeperhost.mm.fcix.net
 d2lzkl7pfhq30w.cloudfront.net
 de.mirrors.cicku.me
@@ -40,6 +41,7 @@ epel.hysing.is
 epel.ip-connect.info
 epel.mirror.constant.com
 epel.mirror.digitalpacific.com.au
+epel.mirror.liquidtelecom.com
 epel.mirror.omnilance.com
 epel.mirror.shastacoe.net
 epel.sg.ssimn.org
@@ -47,7 +49,6 @@ epel.srv.magticom.ge
 epel.stl.us.ssimn.org
 epel.uni-sofia.bg
 es.mirrors.cicku.me
-espejito.fder.edu.uy
 eu.edge.kernel.org
 fastmirror.pp.ua
 fedora-archive.ip-connect.info
@@ -126,7 +127,6 @@ mirror.2degrees.nz
 mirror.aarnet.edu.au
 mirror.accum.se
 mirror.airenetworks.es
-mirror.ams-1.serverforge.org
 mirror.bahnhof.net
 mirror.cedia.org.ec
 mirror.centos.ikoula.com


### PR DESCRIPTION
- Removing the Fedora 39 upstream builds as that release reaches EOL today
- Adding Fedora 41 to the upstream builds.