### PR TITLE
Fixed issue where mirror.servers was getting overwritten with rhproxy installs.

### DIFF
--- a/bin/rhproxy
+++ b/bin/rhproxy
@@ -90,7 +90,7 @@ if [ "${COMMAND}" == "install" ]; then
     copy_container "${container_file}" "${SYSTEMD_USER_PATH}"
   done
 
-  for env_file in "${ENV_PATH}"/*.env "${ENV_PATH}"/*.servers; do
+  for env_file in "${ENV_PATH}"/*.env; do
     copy_env "${env_file}" "${ENV_USER_PATH}"
   done
 

--- a/env/epel.servers
+++ b/env/epel.servers
@@ -1,6 +1,6 @@
 # Dnf/Yum EPEL Servers
-# Updated:        2025-01-22
-# Count:          300
+# Updated:        2025-01-25
+# Count:          301
 # Versions:       4, 5, 6, 7, 8, 9, 10
 # Architectures:  aarch64, armhfp, i386, ppc64, ppc64le, s390x, x86_64
 #
@@ -215,6 +215,7 @@ mirror.umd.edu
 mirror.us-midwest-1.nexcess.net
 mirror.us.leaseweb.net
 mirror.us.mirhosting.net
+mirror.usi.edu
 mirror.uv.es
 mirror.vpsnet.com
 mirror.vsys.host

--- a/rhproxy.spec
+++ b/rhproxy.spec
@@ -1,5 +1,5 @@
 %global base_version 1.5
-%global patch_version 0
+%global patch_version 1
 %global engine_version 1.5.0
 
 Name:           rhproxy
@@ -54,6 +54,9 @@ sed -i 's/{{RHPROXY_ENGINE_RELEASE_TAG}}/%{engine_version}/' %{buildroot}/%{_dat
 %{_datadir}/%{name}/download/bin/configure-client.sh.template
 
 %changelog
+* Sat Jan 25 2025 Alberto Bellotti <abellott@redhat.com> - 1.5.1
+- Fixed an issue where the mirror.server file was getting overwritten.
+
 * Thu Jan 23 2025 Alberto Bellotti <abellott@redhat.com> - 1.5.0
 - GA Release of Insights proxy
 - Now pulling the rhproxy-engine container image 1.5.0 from registry.redhat.io


### PR DESCRIPTION
- Build 1.5.1
- Fixed issue where the mirror.servers was getting overwritten with rhproxy installs.