### PR TITLE
Build 1.5.2 of the RPM

### DIFF
--- a/config/rhproxy.container
+++ b/config/rhproxy.container
@@ -4,7 +4,7 @@ Requires=podman.socket
 
 [Container]
 ContainerName=rhproxy
-Image=registry.redhat.io/insights-proxy/insights-proxy-container/rhproxy-engine:{{RHPROXY_ENGINE_RELEASE_TAG}}
+Image=registry.redhat.io/insights-proxy/insights-proxy-container-rhel9/rhproxy-engine:{{RHPROXY_ENGINE_RELEASE_TAG}}
 PublishPort=3128:3128
 ExposeHostPort=3128
 PublishPort=8443:8443

--- a/env/epel.servers
+++ b/env/epel.servers
@@ -1,5 +1,5 @@
 # Dnf/Yum EPEL Servers
-# Updated:        2025-01-25
+# Updated:        2025-01-27
 # Count:          301
 # Versions:       4, 5, 6, 7, 8, 9, 10
 # Architectures:  aarch64, armhfp, i386, ppc64, ppc64le, s390x, x86_64
@@ -83,7 +83,6 @@ ftp.kaist.ac.kr
 ftp.nluug.nl
 ftp.nsc.ru
 ftp.ntua.gr
-ftp.plusline.net
 ftp.rediris.es
 ftp.riken.jp
 ftp.sh.cvut.cz
@@ -125,6 +124,7 @@ mirror.2degrees.nz
 mirror.aarnet.edu.au
 mirror.accum.se
 mirror.airenetworks.es
+mirror.ams-1.serverforge.org
 mirror.bahnhof.net
 mirror.cedia.org.ec
 mirror.centos.ikoula.com
@@ -151,7 +151,6 @@ mirror.facebook.net
 mirror.fcix.net
 mirror.fjordos.no
 mirror.fmt-2.serverforge.org
-mirror.freedif.org
 mirror.freethought-internet.co.uk
 mirror.genesisadaptive.com
 mirror.gi.co.id
@@ -193,6 +192,7 @@ mirror.nsc.liu.se
 mirror.nyist.edu.cn
 mirror.papua.go.id
 mirror.pilotfiber.com
+mirror.plusline.net
 mirror.ps.kz
 mirror.raiolanetworks.com
 mirror.realcompute.io

--- a/rhproxy.spec
+++ b/rhproxy.spec
@@ -1,5 +1,5 @@
 %global base_version 1.5
-%global patch_version 1
+%global patch_version 2
 %global engine_version 1.5.0
 
 Name:           rhproxy
@@ -54,6 +54,9 @@ sed -i 's/{{RHPROXY_ENGINE_RELEASE_TAG}}/%{engine_version}/' %{buildroot}/%{_dat
 %{_datadir}/%{name}/download/bin/configure-client.sh.template
 
 %changelog
+* Mon Jan 27 2025 Alberto Bellotti <abellott@redhat.com> - 1.5.2
+- Updated the container image repo path in registry.redhat.io.
+
 * Sat Jan 25 2025 Alberto Bellotti <abellott@redhat.com> - 1.5.1
 - Fixed an issue where the mirror.server file was getting overwritten.
 


### PR DESCRIPTION
- Updated RPM build to 1.5.2
- Updated the container image repo path in registry.redhat.io, path requires the `-rhel9` suffix.