### PR TITLE
RPM version 1.5.3 - Updated image repo path in registry.redhat.io

### DIFF
--- a/config/rhproxy.container
+++ b/config/rhproxy.container
@@ -4,7 +4,7 @@ Requires=podman.socket
 
 [Container]
 ContainerName=rhproxy
-Image=registry.redhat.io/insights-proxy/insights-proxy-container-rhel9/rhproxy-engine:{{RHPROXY_ENGINE_RELEASE_TAG}}
+Image=registry.redhat.io/insights-proxy/insights-proxy-container-rhel9:{{RHPROXY_ENGINE_RELEASE_TAG}}
 PublishPort=3128:3128
 ExposeHostPort=3128
 PublishPort=8443:8443

--- a/env/epel.servers
+++ b/env/epel.servers
@@ -1,6 +1,6 @@
 # Dnf/Yum EPEL Servers
-# Updated:        2025-01-27
-# Count:          301
+# Updated:        2025-01-29
+# Count:          300
 # Versions:       4, 5, 6, 7, 8, 9, 10
 # Architectures:  aarch64, armhfp, i386, ppc64, ppc64le, s390x, x86_64
 #
@@ -202,7 +202,6 @@ mirror.sabay.com.kh
 mirror.servaxnet.com
 mirror.sfo12.us.leaseweb.net
 mirror.siena.edu
-mirror.siwoo.org
 mirror.snu.edu.in
 mirror.steadfastnet.com
 mirror.szerverem.hu

--- a/rhproxy.spec
+++ b/rhproxy.spec
@@ -1,5 +1,5 @@
 %global base_version 1.5
-%global patch_version 2
+%global patch_version 3
 %global engine_version 1.5.0
 
 Name:           rhproxy
@@ -54,6 +54,9 @@ sed -i 's/{{RHPROXY_ENGINE_RELEASE_TAG}}/%{engine_version}/' %{buildroot}/%{_dat
 %{_datadir}/%{name}/download/bin/configure-client.sh.template
 
 %changelog
+* Wed Jan 29 2025 Alberto Bellotti <abellott@redhat.com> - 1.5.3
+- Updated the image repo path in registry.redhat.io to exclude rhproxy-engine
+
 * Mon Jan 27 2025 Alberto Bellotti <abellott@redhat.com> - 1.5.2
 - Updated the container image repo path in registry.redhat.io.
 


### PR DESCRIPTION
New RPM version 1.5.3
- Updated container image path in registry.redhat.io to exclude the rhproxy-engine trailing portion of it.