### PR TITLE
Skip setting the SELinux module policy for RHEL8

### DIFF
--- a/bin/get-epel-servers
+++ b/bin/get-epel-servers
@@ -22,7 +22,7 @@ for row in doc('table')[0]:
             if re.match("^/mirrors/EPEL/[^/]*/[^/]*$", href):
                 href_paths = href.split("/")
                 version, arch = href_paths[3], href_paths[4]
-                epel_versions.add(version)
+                epel_versions.add(version.split(".")[0])
                 epel_archs.add(arch)
                 query_params += ["repo=epel-{}&arch={}&country=global".format(version, arch)]
 

--- a/download/bin/configure-client.sh.template
+++ b/download/bin/configure-client.sh.template
@@ -27,8 +27,8 @@ fi
 SUBCMD="${1}"
 shift
 
-export RHEL_RELEASE
 RHEL_RELEASE=$(uname -r | sed 's/^.*\(el[0-9]\+\).*$/\1/')
+export RHEL_RELEASE
 
 function restart_services {
   echo "Restarting Insights Services ..."

--- a/download/bin/configure-client.sh.template
+++ b/download/bin/configure-client.sh.template
@@ -27,6 +27,9 @@ fi
 SUBCMD="${1}"
 shift
 
+export RHEL_RELEASE
+RHEL_RELEASE=$(uname -r | sed 's/^.*\(el[0-9]\+\).*$/\1/')
+
 function restart_services {
   echo "Restarting Insights Services ..."
   systemctl daemon-reload
@@ -36,6 +39,11 @@ function restart_services {
 }
 
 function install_rhcd_selinux_policy {
+  # We don't need to do this for RHEL8
+  if [ "${RHEL_RELEASE}" = "el8" ]; then
+    return
+  fi
+
   # If SELinux is not enabled, we're done.
   if [ ! "$(/usr/sbin/getenforce)" = "Enforcing" ]; then
     return

--- a/env/epel.servers
+++ b/env/epel.servers
@@ -1,6 +1,6 @@
 # Dnf/Yum EPEL Servers
-# Updated:        2025-01-29
-# Count:          300
+# Updated:        2025-02-19
+# Count:          296
 # Versions:       4, 5, 6, 7, 8, 9, 10
 # Architectures:  aarch64, armhfp, i386, ppc64, ppc64le, s390x, x86_64
 #
@@ -33,7 +33,6 @@ download-cc-rdu01.fedoraproject.org
 download.nus.edu.sg
 edgeuno-bog2.mm.fcix.net
 epel.01link.hk
-epel.au.ssimn.org
 epel.grena.ge
 epel.hysing.is
 epel.ip-connect.info
@@ -44,7 +43,6 @@ epel.mirror.liquidtelecom.com
 epel.mirror.omnilance.com
 epel.mirror.shastacoe.net
 epel.srv.magticom.ge
-epel.stl.us.ssimn.org
 epel.uni-sofia.bg
 es.mirrors.cicku.me
 eu.edge.kernel.org
@@ -151,8 +149,8 @@ mirror.facebook.net
 mirror.fcix.net
 mirror.fjordos.no
 mirror.fmt-2.serverforge.org
+mirror.freedif.org
 mirror.freethought-internet.co.uk
-mirror.genesisadaptive.com
 mirror.gi.co.id
 mirror.grid.uchicago.edu
 mirror.hnd.cl
@@ -201,7 +199,6 @@ mirror.rnet.missouri.edu
 mirror.sabay.com.kh
 mirror.servaxnet.com
 mirror.sfo12.us.leaseweb.net
-mirror.siena.edu
 mirror.snu.edu.in
 mirror.steadfastnet.com
 mirror.szerverem.hu
@@ -299,7 +296,6 @@ tw.mirrors.cicku.me
 ucmirror.canterbury.ac.nz
 us.mirrors.cicku.me
 uvermont.mm.fcix.net
-veronanetworks.mm.fcix.net
 volico.mm.fcix.net
 www.gtlib.gatech.edu
 www.nic.funet.fi


### PR DESCRIPTION
Skip setting the SELinux module policy for RHEL8 as it's not needed there.
- https://issues.redhat.com/projects/IPP/issues/IPP-26

Also requires an rhcd update as per:
- https://issues.redhat.com/browse/CCT-1185