### PR TITLE
Bumping rhproxy RPM version to 1.5.4

### DIFF
--- a/env/epel.servers
+++ b/env/epel.servers
@@ -1,5 +1,5 @@
 # Dnf/Yum EPEL Servers
-# Updated:        2025-02-19
+# Updated:        2025-02-26
 # Count:          296
 # Versions:       4, 5, 6, 7, 8, 9, 10
 # Architectures:  aarch64, armhfp, i386, ppc64, ppc64le, s390x, x86_64
@@ -27,6 +27,7 @@ creeperhost.mm.fcix.net
 d2lzkl7pfhq30w.cloudfront.net
 de.mirrors.cicku.me
 dfw.mirror.rackspace.com
+distrohub.kyiv.ua
 divergentnetworks.mm.fcix.net
 dl.fedoraproject.org
 download-cc-rdu01.fedoraproject.org
@@ -46,7 +47,6 @@ epel.srv.magticom.ge
 epel.uni-sofia.bg
 es.mirrors.cicku.me
 eu.edge.kernel.org
-fastmirror.pp.ua
 fedora-archive.ip-connect.info
 fedora-archive.ip-connect.vn.ua
 fedora-archive.mirror.liquidtelecom.com
@@ -246,7 +246,7 @@ mirrors.nxthost.com
 mirrors.powernet.com.ru
 mirrors.ptisp.pt
 mirrors.qlu.edu.cn
-mirrors.rit.edu
+mirrors.rc.rit.edu
 mirrors.sohu.com
 mirrors.sonic.net
 mirrors.tuna.tsinghua.edu.cn

--- a/rhproxy.spec
+++ b/rhproxy.spec
@@ -1,6 +1,6 @@
 %global base_version 1.5
-%global patch_version 3
-%global engine_version 1.5.0
+%global patch_version 4
+%global engine_version 1.5.1
 
 Name:           rhproxy
 Version:        %{base_version}.%{patch_version}
@@ -54,6 +54,10 @@ sed -i 's/{{RHPROXY_ENGINE_RELEASE_TAG}}/%{engine_version}/' %{buildroot}/%{_dat
 %{_datadir}/%{name}/download/bin/configure-client.sh.template
 
 %changelog
+* Wed Feb 26 2025 Alberto Bellotti <abellott@redhat.com> - 1.5.4
+- Now pulling the rhproxy-engine container image 1.5.1 from registry.redhat.io
+- Skip setting the SELinux module policy in configure-client.sh, not needed for RHEL8
+
 * Wed Jan 29 2025 Alberto Bellotti <abellott@redhat.com> - 1.5.3
 - Updated the image repo path in registry.redhat.io to exclude rhproxy-engine
 


### PR DESCRIPTION
- Now pulling the rhproxy-engine container image 1.5.1 from registry.redhat.io
- Skip setting the SELinux module policy in configure-client.sh, not needed for RHEL8