### PR TITLE
add support for testing a custom image path

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -127,6 +127,14 @@ The RPM must exist on the system where the playbook was launched, and it will be
 proxy node. Alternatively, if the RPM is reachable from the proxy node using a URL, set the
 `rpm_name` variable to this URL; also use `unsigned=True` if this RPM isn't signed.
 
+You can also override the image path in the quadlet service file if you want to pull an image that
+differs from the one in this file: for example, to pull a new test image at Quay while testing an
+rhproxy RPM build that uses the Red Hat registry. To do so, add the following extra variable:
+
+```
+image_override=<REGISTRY_HOST/IMAGE_PATH:VERSION>
+```
+
 ## Notes
 To enable logging for easier sharing of the output, run the `ansible-playbook` command with
 `ANSIBLE_LOG_PATH=/some/file`.

--- a/tests/server/main.yml
+++ b/tests/server/main.yml
@@ -58,6 +58,14 @@
     become_user: "{{ local_user }}"
     tags: user_login
 
+  - name: override the image path if needed
+    lineinfile:
+      path: /usr/share/rhproxy/config/rhproxy.container
+      regexp: "^Image="
+      line: Image={{ image_override }}
+    when: image_override is defined
+    tags: service_install
+
   - name: install the proxy
     command: "{{ command }} install"
     become_user: "{{ local_user }}"


### PR DESCRIPTION
This commit allows one to supply a container image path to use instead of the one in the quadlet service file. When the corresponding Ansible extra variable is used, the path is replaced in the system-wide service file, which gets copied to the rhproxy user's home directory by `rhproxy install`, and then `rhproxy start` pulls the specified image.