### PR TITLE
test RHC, also on RHEL 8 by default

### DIFF
--- a/env/epel.servers
+++ b/env/epel.servers
@@ -1,6 +1,6 @@
 # Dnf/Yum EPEL Servers
-# Updated:        2025-02-27
-# Count:          296
+# Updated:        2025-03-10
+# Count:          298
 # Versions:       4, 5, 6, 7, 8, 9, 10
 # Architectures:  aarch64, armhfp, i386, ppc64, ppc64le, s390x, x86_64
 #
@@ -119,6 +119,7 @@ mirror.01link.hk
 mirror.0xem.ma
 mirror.23m.com
 mirror.2degrees.nz
+mirror.5i.fi
 mirror.aarnet.edu.au
 mirror.accum.se
 mirror.airenetworks.es
@@ -289,6 +290,7 @@ ryamer.mm.fcix.net
 sa.mirrors.cicku.me
 sg.mirrors.cicku.me
 sjc.mirror.rackspace.com
+solidrock.mm.fcix.net
 southfront.mm.fcix.net
 stix.mm.fcix.net
 syd.mirror.rackspace.com

--- a/tests/README.md
+++ b/tests/README.md
@@ -60,8 +60,8 @@ Run the provided script:
 $ ./create-cf-stack.py
 ```
 
-With no arguments, it creates a stack with a RHEL 9 x86\_64 system for the proxy and the same
-configuration for a client. The current date (YYYYMMDD) is used for the name.
+With no arguments, it creates a stack with a RHEL 9 x86\_64 system for the proxy and two more client
+sytems running RHEL 8 and 9, both using x86\_64. The current date (YYYYMMDD) is used for the name.
 
 See the output from `--help` for more information. Notably, you may wish to use a different region,
 name, architecture for the proxy server, or change the number of RHEL 9 or 8 clients (even to 0).

--- a/tests/README.md
+++ b/tests/README.md
@@ -61,7 +61,7 @@ $ ./create-cf-stack.py
 ```
 
 With no arguments, it creates a stack with a RHEL 9 x86\_64 system for the proxy and two more client
-sytems running RHEL 8 and 9, both using x86\_64. The current date (YYYYMMDD) is used for the name.
+systems running RHEL 8 and 9, both using x86\_64. The current date (YYYYMMDD) is used for the name.
 
 See the output from `--help` for more information. Notably, you may wish to use a different region,
 name, architecture for the proxy server, or change the number of RHEL 9 or 8 clients (even to 0).

--- a/tests/create-cf-stack.py
+++ b/tests/create-cf-stack.py
@@ -24,7 +24,7 @@ argparser = argparse.ArgumentParser(description='Create CloudFormation stack for
                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
 argparser.add_argument('--name', help='common name for stack members', default=time.strftime("%Y%m%d"))
-argparser.add_argument('--cli8', help='number of RHEL8 clients', type=int, default=0)
+argparser.add_argument('--cli8', help='number of RHEL8 clients', type=int, default=1)
 argparser.add_argument('--cli8-arch', help='RHEL 8 clients\' architectures (comma-separated list)', default='x86_64', metavar='ARCH')
 argparser.add_argument('--cli9', help='number of RHEL9 clients', type=int, default=1)
 argparser.add_argument('--cli9-arch', help='RHEL 9 clients\' architectures (comma-separated list)', default='x86_64', metavar='ARCH')

--- a/tests/rhc/main.yml
+++ b/tests/rhc/main.yml
@@ -1,0 +1,56 @@
+# Tests for RHC
+#
+- hosts: all
+  tasks:
+  - name: block for client tasks
+    block:
+      - name: remove PID files
+      # needed before yggdrasil PR 299
+        file:
+          path: "{{ item }}"
+          state: absent
+        with_items:
+          - /var/run/rhc/workers/rhc-worker-playbook.worker.pid
+          - /var/run/rhc/workers/rhc-package-manager-worker.pid
+
+      - name: restart the rhc daemon
+        systemd_service:
+          name: rhcd
+          state: restarted
+
+      - name: wait two minutes and get the rhc daemon status report
+      # can't use the pause module due to Ansible issue 19966
+        shell: "sleep 120 ; systemctl status rhcd"
+        register: daemon_status
+        changed_when: false
+        failed_when: "'failed to start worker' in daemon_status.stdout"
+        # ignore before rhc-worker-playbook PR 56
+        ignore_errors: true
+
+      - name: display the rhc daemon status report
+        debug:
+          msg: "{{ daemon_status.stdout }}"
+
+      - name: get the rhc client status report
+        command: rhc status
+        register: client_status
+        changed_when: false
+
+      - name: display the rhc client status report
+        debug:
+          msg: "{{ client_status.stdout }}"
+    when: inventory_hostname in groups['CLI']
+    tags: rhc
+
+  - name: block for server tasks
+    block:
+      - name: check the server log
+        command: podman logs rhproxy
+        become_user: "{{ local_user }}"
+        register: podman_logs_2
+        failed_when: "'CONNECT yggd' in podman_logs_2.stdout"
+        changed_when: false
+        # ignore before rhc-worker-playbook PR 56
+        ignore_errors: true
+    when: inventory_hostname in groups['PROXY']
+    tags: rhc

--- a/tests/setup/main.yml
+++ b/tests/setup/main.yml
@@ -22,3 +22,10 @@
       name: iptables
       state: present
     tags: build_firewall
+
+  - name: make sure the playbook package is installed on the clients
+    package:
+      name: rhc-worker-playbook
+      state: latest
+    when: inventory_hostname in groups['CLI']
+    tags: rpm_install

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -5,6 +5,7 @@
 - import_playbook: server/main.yml
 - import_playbook: client/main.yml
 - import_playbook: insights/main.yml
+- import_playbook: rhc/main.yml
 - import_playbook: rhsm_repos/main.yml
 - import_playbook: epel/main.yml
 - import_playbook: custom_repos/main.yml


### PR DESCRIPTION
Adding tests for RHC. At present, there are issues with RHC & proxies, so the affected tests use `ignore_errors` so as not to fail and halt the whole test suite, but the failures are clearly visible:

```
Mar 10 15:15:57 ip-10-0-0-181.eu-west-1.compute.internal rhcd[27766]: [rhcd] 2025/03/10 15:15:57 cannot restart worker: failed to start worker /usr/libexec/rhc/rhc-worker-playbook.worker too many times
...ignoring

...

10.0.0.181 - - [10/Mar/2025:15:13:08 +0000] "CONNECT yggd-dispatcher-tPKVGy:443 HTTP/1.1" 404 153 "-" "grpc-httpcli/0.0"

...

PLAY RECAP ***
<hostname> : ok=43   changed=26   unreachable=0    failed=0    skipped=10   rescued=0    ignored=1
```

Also, the AWS stack creation script now launches a RHEL 8 client VM by default. Lastly, the EPEL mirror list has been updated.