### PR TITLE
fix a mistake in the firewall configuration of the test environment

### DIFF
--- a/env/epel.servers
+++ b/env/epel.servers
@@ -1,6 +1,6 @@
 # Dnf/Yum EPEL Servers
-# Updated:        2025-03-10
-# Count:          298
+# Updated:        2025-03-14
+# Count:          294
 # Versions:       4, 5, 6, 7, 8, 9, 10
 # Architectures:  aarch64, armhfp, i386, ppc64, ppc64le, s390x, x86_64
 #
@@ -115,7 +115,6 @@ lolhost.mm.fcix.net
 mirror-icn.yuki.net.uk
 mirror-mci.yuki.net.uk
 mirror-nrt.yuki.net.uk
-mirror.01link.hk
 mirror.0xem.ma
 mirror.23m.com
 mirror.2degrees.nz
@@ -148,7 +147,6 @@ mirror.etf.bg.ac.rs
 mirror.euserv.net
 mirror.facebook.net
 mirror.fcix.net
-mirror.fjordos.no
 mirror.fmt-2.serverforge.org
 mirror.freedif.org
 mirror.freethought-internet.co.uk
@@ -200,7 +198,6 @@ mirror.rnet.missouri.edu
 mirror.sabay.com.kh
 mirror.servaxnet.com
 mirror.sfo12.us.leaseweb.net
-mirror.snu.edu.in
 mirror.steadfastnet.com
 mirror.szerverem.hu
 mirror.team-cymru.com
@@ -297,7 +294,6 @@ syd.mirror.rackspace.com
 tw.mirrors.cicku.me
 ucmirror.canterbury.ac.nz
 us.mirrors.cicku.me
-uvermont.mm.fcix.net
 volico.mm.fcix.net
 www.gtlib.gatech.edu
 www.nic.funet.fi

--- a/tests/server/main.yml
+++ b/tests/server/main.yml
@@ -17,7 +17,7 @@
     tags: build_firewall
 
   - name: deny access to the proxy web port to others
-    command: iptables -A INPUT -p tcp --dport 3128 -j REJECT
+    command: iptables -A INPUT -p tcp --dport 8443 -j REJECT
     tags: build_firewall
 
   - name: enable the Insights proxy repo


### PR DESCRIPTION
Due to my lazy copying&pasting, access to the proxy port from foreign IPs was denied twice in the Insights proxy server firewall setup, but access to the web server wasn't limited. This commit resolves that. Another commit is attached to update the EPEL mirror list.