### PR TITLE
instruct readers to use the GA repo rather than Tech Preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,22 @@ First, enable the appropriate repo then install the `rhproxy` RPM:
 
 ## Enabling the RPM Repo:
 
-### For Tech Preview Builds:
+### For General Availability Builds:
 
 #### X86_64
 
 ```sh
-# sudo subscription-manager repos --enable insights-proxy-1-tech-preview-for-rhel-9-x86_64-rpms
+# sudo subscription-manager repos --enable insights-proxy-for-rhel-9-x86_64-rpms
 ```
 
 #### AARCH64
 
 ```sh
-# sudo subscription-manager repos --enable insights-proxy-1-tech-preview-for-rhel-9-aarch64-rpms
+# sudo subscription-manager repos --enable insights-proxy-for-rhel-9-aarch64-rpms
 ```
+
+> [!IMPORTANT]
+> Be sure to enable this GA repository, update the RPM, and reinstall the service if you have installed a Technology Preview build before.
 
 ### For Upstream Release Builds:
 

--- a/env/epel.servers
+++ b/env/epel.servers
@@ -1,6 +1,6 @@
 # Dnf/Yum EPEL Servers
-# Updated:        2025-03-14
-# Count:          294
+# Updated:        2025-03-25
+# Count:          292
 # Versions:       4, 5, 6, 7, 8, 9, 10
 # Architectures:  aarch64, armhfp, i386, ppc64, ppc64le, s390x, x86_64
 #
@@ -97,7 +97,6 @@ hkg.mirror.rackspace.com
 iad.mirror.rackspace.com
 in.mirrors.cicku.me
 insect.mm.fcix.net
-ipng.mm.fcix.net
 irltoolkit.mm.fcix.net
 it1.mirror.vhosting-it.com
 it2.mirror.vhosting-it.com
@@ -147,6 +146,7 @@ mirror.etf.bg.ac.rs
 mirror.euserv.net
 mirror.facebook.net
 mirror.fcix.net
+mirror.fjordos.no
 mirror.fmt-2.serverforge.org
 mirror.freedif.org
 mirror.freethought-internet.co.uk
@@ -198,7 +198,6 @@ mirror.rnet.missouri.edu
 mirror.sabay.com.kh
 mirror.servaxnet.com
 mirror.sfo12.us.leaseweb.net
-mirror.steadfastnet.com
 mirror.szerverem.hu
 mirror.team-cymru.com
 mirror.telepoint.bg
@@ -206,7 +205,6 @@ mirror.theory7.net
 mirror.tornadovps.com
 mirror.twds.com.tw
 mirror.umd.edu
-mirror.us-midwest-1.nexcess.net
 mirror.us.leaseweb.net
 mirror.us.mirhosting.net
 mirror.usi.edu


### PR DESCRIPTION
The Tech Preview repo is obsolete and contains an outdated version of rhproxy. This commit updates the README file with the GA repo and suggests updating to those users who have installed the Tech Preview. As always, the EPEL mirror list has been updated, too.