### PR TITLE
build: Bumping rhproxy RPM version to 1.5.5

### DIFF
--- a/rhproxy.spec
+++ b/rhproxy.spec
@@ -1,6 +1,6 @@
 %global base_version 1.5
-%global patch_version 4
-%global engine_version 1.5.1
+%global patch_version 5
+%global engine_version 1.5.2
 
 Name:           rhproxy
 Version:        %{base_version}.%{patch_version}
@@ -54,6 +54,10 @@ sed -i 's/{{RHPROXY_ENGINE_RELEASE_TAG}}/%{engine_version}/' %{buildroot}/%{_dat
 %{_datadir}/%{name}/download/bin/configure-client.sh.template
 
 %changelog
+* Mon Apr 28 2025 Alberto Bellotti <abellott@redhat.com> - 1.5.5
+- Updated configuration script to fix an issue around remediations on RHEL8 and RHEL9.
+- Enabled insights-proxy tagging for the insights-client connections to Insights.
+
 * Wed Feb 26 2025 Alberto Bellotti <abellott@redhat.com> - 1.5.4
 - Now pulling the rhproxy-engine container image 1.5.1 from registry.redhat.io
 - Skip setting the SELinux module policy in configure-client.sh, not needed for RHEL8


### PR DESCRIPTION
Bumping rhproxy RPM version to 1.5.5

- Updated configuration script to fix an issue around remediations on RHEL8 and RHEL9.
- Enabled insights-proxy tagging for the insights-client to allow tracking number of connections via the proxy.