### PR TITLE
Changes to the test suite for Insight proxy version 1.5.5

### DIFF
--- a/env/epel.servers
+++ b/env/epel.servers
@@ -1,6 +1,6 @@
 # Dnf/Yum EPEL Servers
-# Updated:        2025-04-28
-# Count:          274
+# Updated:        2025-05-07
+# Count:          265
 # Versions:       4, 5, 6, 7, 8, 9, 10
 # Architectures:  aarch64, armhfp, i386, ppc64, ppc64le, s390x, x86_64
 #
@@ -13,7 +13,6 @@ atl.mirrors.knownhost.com
 b4sh.mm.fcix.net
 bungi.mm.fcix.net
 ca.mirrors.cicku.me
-cdn.fjordos.no
 centos.anexia.at
 codingflyboy.mm.fcix.net
 cofractal-ewr.mm.fcix.net
@@ -94,7 +93,6 @@ it2.mirror.vhosting-it.com
 ix-denver.mm.fcix.net
 lchs.mm.fcix.net
 lesnet.mm.fcix.net
-level66.mm.fcix.net
 linux-mirrors.fnal.gov
 linux.mirrors.es.net
 linuxsoft.cern.ch
@@ -134,7 +132,6 @@ mirror.etf.bg.ac.rs
 mirror.euserv.net
 mirror.facebook.net
 mirror.fcix.net
-mirror.fjordos.no
 mirror.fmt-2.serverforge.org
 mirror.freedif.org
 mirror.freethought-internet.co.uk
@@ -155,7 +152,6 @@ mirror.karneval.cz
 mirror.lanet.network
 mirror.lax.adaptivedatanetworks.com
 mirror.layeronline.com
-mirror.linux-ia64.org
 mirror.logol.ru
 mirror.lstn.net
 mirror.maeen.sa
@@ -163,7 +159,6 @@ mirror.mangohost.net
 mirror.marwan.ma
 mirror.math.princeton.edu
 mirror.mci-1.serverforge.org
-mirror.metrocast.net
 mirror.netcologne.de
 mirror.netone.nl
 mirror.netsite.dk
@@ -182,21 +177,18 @@ mirror.ps.kz
 mirror.raiolanetworks.com
 mirror.realcompute.io
 mirror.rise.ph
-mirror.rnet.missouri.edu
 mirror.sabay.com.kh
 mirror.servaxnet.com
 mirror.sfo12.us.leaseweb.net
 mirror.szerverem.hu
 mirror.team-cymru.com
 mirror.telepoint.bg
-mirror.theory7.net
 mirror.tornadovps.com
 mirror.twds.com.tw
 mirror.umd.edu
 mirror.us.leaseweb.net
 mirror.us.mirhosting.net
 mirror.usi.edu
-mirror.uv.es
 mirror.vpsnet.com
 mirror.vsys.host
 mirror.wd6.net
@@ -206,6 +198,7 @@ mirror.yandex.ru
 mirror.yer.az
 mirror.za.abantu.cloud
 mirrors.20i.com
+mirrors.bytes.ua
 mirrors.cat.pdx.edu
 mirrors.chroot.ro
 mirrors.coreix.net
@@ -228,7 +221,6 @@ mirrors.neusoft.edu.cn
 mirrors.nic.cz
 mirrors.nxthost.com
 mirrors.powernet.com.ru
-mirrors.ptisp.pt
 mirrors.qlu.edu.cn
 mirrors.rc.rit.edu
 mirrors.sohu.com
@@ -252,7 +244,6 @@ ohioix.mm.fcix.net
 opencolo.mm.fcix.net
 ord.mirror.rackspace.com
 packages.oit.ncsu.edu
-paducahix.mm.fcix.net
 pkg.adfinis-on-exoscale.ch
 pkg.adfinis.com
 pubmirror1.math.uh.edu

--- a/tests/group_vars/all.yml
+++ b/tests/group_vars/all.yml
@@ -9,6 +9,9 @@ registry:
   password: "{{ lookup('ini', 'password section=' + registry_alias + ' file=../credentials.conf') }}"
 rh_username: "{{ lookup('ini', 'username section=rh file=../credentials.conf') }}"
 rh_password: "{{ lookup('ini', 'password section=rh file=../credentials.conf') }}"
+#rh_client_id: "{{ lookup('ini', 'client_id section=rh file=../credentials.conf') }}"
+#rh_client_secret: "{{ lookup('ini', 'client_secret section=rh file=../credentials.conf') }}"
+rh_offline_token: "{{ lookup('ini', 'offline_token section=rh file=../credentials.conf') }}"
 container: "{{ 'insights-proxy' if registry_alias == 'rh' else 'insights_proxy' }}"
 rpm_name: rhproxy
 local_user: rhproxy

--- a/tests/insights/main.yml
+++ b/tests/insights/main.yml
@@ -25,3 +25,48 @@
     command: insights-client
     changed_when: false
     tags: insights
+
+  - name: generate an access token
+    local_action:
+      module: uri
+      url: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+      method: POST
+      body_format: form-urlencoded
+      body:
+        # grant type "client credentials" works only if the service account has the right privileges
+        #grant_type: client_credentials
+        #scope: api.console
+        #client_id: "{{ rh_client_id }}"
+        #client_secret: "{{ rh_client_secret }}"
+        grant_type: refresh_token
+        client_id: rhsm-api
+        refresh_token: "{{ rh_offline_token }}"
+    run_once: True
+    become: false
+    register: insights_auth
+    tags: insights
+
+  - name: ask Red Hat Console for the hosts that use this proxy
+    local_action:
+      module: uri
+      url: "https://console.redhat.com/api/inventory/v1/hosts?tags=insights-client%2Finsights-proxy%3D{{ server }}"
+      headers:
+        Authorization: "Bearer {{ insights_auth.json.access_token }}"
+    run_once: True
+    become: false
+    register: api_response
+    tags: insights
+
+  - name: Display results
+    debug:
+      var: api_response.json
+    run_once: True
+    tags: insights
+
+  - name: check if the number of systems matches the number of clients
+    assert:
+      that: groups['CLI'] | length == api_response.json.count
+      success_msg: "OK, {{ api_response.json.count }}"
+      fail_msg: "Not OK, {{ api_response.json.count }}"
+    run_once: True
+    tags: insights

--- a/tests/rhc/main.yml
+++ b/tests/rhc/main.yml
@@ -4,28 +4,12 @@
   tasks:
   - name: block for client tasks
     block:
-      - name: remove PID files
-      # needed before yggdrasil PR 299
-        file:
-          path: "{{ item }}"
-          state: absent
-        with_items:
-          - /var/run/rhc/workers/rhc-worker-playbook.worker.pid
-          - /var/run/rhc/workers/rhc-package-manager-worker.pid
-
-      - name: restart the rhc daemon
-        systemd_service:
-          name: rhcd
-          state: restarted
-
       - name: wait two minutes and get the rhc daemon status report
       # can't use the pause module due to Ansible issue 19966
         shell: "sleep 120 ; systemctl status rhcd"
         register: daemon_status
         changed_when: false
         failed_when: "'failed to start worker' in daemon_status.stdout"
-        # ignore before rhc-worker-playbook PR 56
-        ignore_errors: true
 
       - name: display the rhc daemon status report
         debug:
@@ -50,7 +34,5 @@
         register: podman_logs_2
         failed_when: "'CONNECT yggd' in podman_logs_2.stdout"
         changed_when: false
-        # ignore before rhc-worker-playbook PR 56
-        ignore_errors: true
     when: inventory_hostname in groups['PROXY']
     tags: rhc

--- a/tests/server/main.yml
+++ b/tests/server/main.yml
@@ -23,19 +23,19 @@
   - name: enable the Insights proxy repo
     rhsm_repository:
       name: insights-proxy-for-rhel-9-{{ ansible_architecture }}-rpms
-    when: local_rpm is not defined
+    when: rpm_override is not defined
     tags: subscribe
 
   - name: copy a local Insights proxy RPM
     copy:
-      src: "{{ local_rpm }}"
+      src: "{{ rpm_override }}"
       dest: /tmp
-    when: local_rpm is defined
-    tags: local_rpm
+    when: rpm_override is defined and '://' not in rpm_override
+    tags: rpm_install
 
   - name: install the Insights proxy RPM
     package:
-      name: "{{ local_rpm | default(rpm_name) }}"
+      name: "{{ (('://' in rpm_override) | ternary(rpm_override, '/tmp/' + rpm_override|basename)) if rpm_override is defined else rpm_name }}"
       state: latest
       disable_gpg_check: "{{ unsigned | default(False) | bool }}"
     tags: rpm_install
@@ -104,6 +104,15 @@
     failed_when: "registry['host'] + '/' + container not in containers.stdout"
     changed_when: false
     tags: container_list
+
+  - name: check the engine version
+    command: "podman images --format '{% raw %}{{.Tag}}{% endraw %}'"
+    become_user: "{{ local_user }}"
+    register: actual_engine_version
+    failed_when: actual_engine_version.stdout != expected_engine_version
+    changed_when: false
+    when: expected_engine_version is defined
+    tags: version_check
 
   - name: test the proxy from the server
     command: "curl -L -x http://{{ server }}:3128 https://{{ test_good_host }}/"


### PR DESCRIPTION
Updating the test suite to check new features and remove previous workarounds. Also updating the list of EPEL mirrors.