### PR TITLE
update the AMI IDs to 9.6

### DIFF
--- a/env/epel.servers
+++ b/env/epel.servers
@@ -1,6 +1,6 @@
 # Dnf/Yum EPEL Servers
-# Updated:        2025-05-07
-# Count:          265
+# Updated:        2025-05-20
+# Count:          263
 # Versions:       4, 5, 6, 7, 8, 9, 10
 # Architectures:  aarch64, armhfp, i386, ppc64, ppc64le, s390x, x86_64
 #
@@ -21,13 +21,11 @@ coresite-atl.mm.fcix.net
 creeperhost.mm.fcix.net
 d2lzkl7pfhq30w.cloudfront.net
 dfw.mirror.rackspace.com
-distrohub.kyiv.ua
 divergentnetworks.mm.fcix.net
 dl.fedoraproject.org
 download-cc-rdu01.fedoraproject.org
 download.nus.edu.sg
 edgeuno-bog2.mm.fcix.net
-epel.01link.hk
 epel.grena.ge
 epel.hysing.is
 epel.ip-connect.info
@@ -45,6 +43,7 @@ fedora-archive.ip-connect.vn.ua
 fedora-archive.mirror.liquidtelecom.com
 fedora-epel.koyanet.lv
 fedora-epel.mirror.iweb.com
+fedora-mirror.cloud.mu
 fedora-mirror02.rbc.ru
 fedora.cs.nctu.edu.tw
 fedora.cu.be
@@ -126,12 +125,12 @@ mirror.datacenter.by
 mirror.de.leaseweb.net
 mirror.digitalnova.at
 mirror.dogado.de
-mirror.dst.ca
 mirror.efect.ro
 mirror.etf.bg.ac.rs
 mirror.euserv.net
 mirror.facebook.net
 mirror.fcix.net
+mirror.fjordos.com
 mirror.fmt-2.serverforge.org
 mirror.freedif.org
 mirror.freethought-internet.co.uk
@@ -148,6 +147,7 @@ mirror.imt-systems.com
 mirror.in2p3.fr
 mirror.init7.net
 mirror.its.dal.ca
+mirror.its.umich.edu
 mirror.karneval.cz
 mirror.lanet.network
 mirror.lax.adaptivedatanetworks.com
@@ -196,8 +196,8 @@ mirror.wiseglobalsolutions.com
 mirror.xenyth.net
 mirror.yandex.ru
 mirror.yer.az
-mirror.za.abantu.cloud
 mirrors.20i.com
+mirrors.bfsu.edu.cn
 mirrors.bytes.ua
 mirrors.cat.pdx.edu
 mirrors.chroot.ro
@@ -223,7 +223,6 @@ mirrors.nxthost.com
 mirrors.powernet.com.ru
 mirrors.qlu.edu.cn
 mirrors.rc.rit.edu
-mirrors.sohu.com
 mirrors.sonic.net
 mirrors.tuna.tsinghua.edu.cn
 mirrors.ukfast.co.uk
@@ -251,7 +250,6 @@ pubmirror2.math.uh.edu
 pubmirror3.math.uh.edu
 reflector.westga.edu
 rep-epel-il.upress.io
-repo.boun.edu.tr
 repo.extreme-ix.org
 repo.ialab.dsu.edu
 repo.jing.rocks

--- a/tests/RHEL9mapping.json
+++ b/tests/RHEL9mapping.json
@@ -1,98 +1,98 @@
 {
     "af-south-1": {
-        "AMI": "ami-0ae4dc25c4c4ddb11"
+        "AMI": "ami-07f4b8c975451cecb"
     },
     "ap-east-1": {
-        "AMI": "ami-0f250af3e7c0e196e"
+        "AMI": "ami-0fd9d8057789b2545"
     },
     "ap-northeast-1": {
-        "AMI": "ami-089a905b97d06f8ca"
+        "AMI": "ami-09b7ba44014f33dca"
     },
     "ap-northeast-2": {
-        "AMI": "ami-05466046c6ffa04b4"
+        "AMI": "ami-0de1f0d7eb54663ca"
     },
     "ap-northeast-3": {
-        "AMI": "ami-02f2305a20f6df535"
+        "AMI": "ami-02a1a7caa150cec45"
     },
     "ap-south-1": {
-        "AMI": "ami-05f5d5d81a591e6e0"
+        "AMI": "ami-0ea42a3786434655c"
     },
     "ap-south-2": {
-        "AMI": "ami-0a88c372bda762199"
+        "AMI": "ami-08c12a9ed7445d003"
     },
     "ap-southeast-1": {
-        "AMI": "ami-05fd07d390d28c617"
+        "AMI": "ami-0f301346d7e7bbe56"
     },
     "ap-southeast-2": {
-        "AMI": "ami-0a27e5c739fe4fdf3"
+        "AMI": "ami-00c7b30ce9351e253"
     },
     "ap-southeast-3": {
-        "AMI": "ami-0615e7f3ba2541e70"
+        "AMI": "ami-038de5a8453cdaeac"
     },
     "ap-southeast-4": {
-        "AMI": "ami-0728277530eb27de3"
+        "AMI": "ami-087d23ef839e764b6"
     },
     "ap-southeast-5": {
-        "AMI": "ami-078dd03f7c3979039"
+        "AMI": "ami-0eea715a6bf5e9279"
     },
     "ap-southeast-7": {
-        "AMI": "ami-0426661bbcd68011f"
+        "AMI": "ami-03c5584ce1e3597d3"
     },
     "ca-central-1": {
-        "AMI": "ami-0f6e5e5bd88e94f8f"
+        "AMI": "ami-0b7503e03bfa6b9fb"
     },
     "ca-west-1": {
-        "AMI": "ami-019aba3859b9aa054"
+        "AMI": "ami-0f9c52dbfb2c4470b"
     },
     "eu-central-1": {
-        "AMI": "ami-0abb375a9635d5426"
+        "AMI": "ami-0d682038d55be0fbc"
     },
     "eu-central-2": {
-        "AMI": "ami-030a8a7a827eb9299"
+        "AMI": "ami-0bc5e9703c6e2f8a1"
     },
     "eu-north-1": {
-        "AMI": "ami-0c98b7a5abf66007c"
+        "AMI": "ami-0298e94b5c99d7cdc"
     },
     "eu-south-1": {
-        "AMI": "ami-0dd2ed8faada464ad"
+        "AMI": "ami-04d155f363e91b1e4"
     },
     "eu-south-2": {
-        "AMI": "ami-09fc8d7fd66f77a87"
+        "AMI": "ami-02e0a2abba6d7422a"
     },
     "eu-west-1": {
-        "AMI": "ami-0779a800165cf507d"
+        "AMI": "ami-0c1ae29043ff9785d"
     },
     "eu-west-2": {
-        "AMI": "ami-0de81fada882bf6f4"
+        "AMI": "ami-0b3a59ac043c7696e"
     },
     "eu-west-3": {
-        "AMI": "ami-0a88431171774c947"
+        "AMI": "ami-03a08fe4ae2f0d25d"
     },
     "il-central-1": {
-        "AMI": "ami-027d9f4c751313320"
+        "AMI": "ami-0e6af6c7c36510558"
     },
     "me-central-1": {
-        "AMI": "ami-0ec99677532c8d16a"
+        "AMI": "ami-08c1d9010d4f471f7"
     },
     "me-south-1": {
-        "AMI": "ami-06da621a4f1063634"
+        "AMI": "ami-098d25e0635bf9723"
     },
     "mx-central-1": {
-        "AMI": "ami-08b9ccc1d68c0035b"
+        "AMI": "ami-0d9d41ca4a68fbd6d"
     },
     "sa-east-1": {
-        "AMI": "ami-0d897d354c71eccc5"
+        "AMI": "ami-069068eb2f28c2371"
     },
     "us-east-1": {
-        "AMI": "ami-0673a5faaca9a47cb"
+        "AMI": "ami-01a52a1073599b7c8"
     },
     "us-east-2": {
-        "AMI": "ami-0f6aca4af98a5c511"
+        "AMI": "ami-037e488c5d0f0468f"
     },
     "us-west-1": {
-        "AMI": "ami-04ed036c51114d65a"
+        "AMI": "ami-0802a76dd06814c1c"
     },
     "us-west-2": {
-        "AMI": "ami-0a5ff62d17dbe0029"
+        "AMI": "ami-08bdc2497d9167fab"
     }
 }

--- a/tests/RHEL9mapping_arm64.json
+++ b/tests/RHEL9mapping_arm64.json
@@ -1,98 +1,98 @@
 {
     "af-south-1": {
-        "AMI": "ami-0c9902d286f42f203"
+        "AMI": "ami-0b5c761dd28e81028"
     },
     "ap-east-1": {
-        "AMI": "ami-005b49b5d8aae56c5"
+        "AMI": "ami-0d51cbcade87db171"
     },
     "ap-northeast-1": {
-        "AMI": "ami-0371ffc0fbe36bdcd"
+        "AMI": "ami-02db9aad853b5825b"
     },
     "ap-northeast-2": {
-        "AMI": "ami-0983dd2b12cc28644"
+        "AMI": "ami-065f7fc2e225138f9"
     },
     "ap-northeast-3": {
-        "AMI": "ami-0accb283c7258056d"
+        "AMI": "ami-07408228dda1ab27a"
     },
     "ap-south-1": {
-        "AMI": "ami-0d9e14f5f72647b1b"
+        "AMI": "ami-03e47c64b2c808eb0"
     },
     "ap-south-2": {
-        "AMI": "ami-0f99f34be431d6612"
+        "AMI": "ami-0f9f80f3bf38297f5"
     },
     "ap-southeast-1": {
-        "AMI": "ami-08e1857a9f1ae9dc2"
+        "AMI": "ami-03b9ca43f3488b584"
     },
     "ap-southeast-2": {
-        "AMI": "ami-01d1e61465d6c5d54"
+        "AMI": "ami-0d862bb8d1956b6d9"
     },
     "ap-southeast-3": {
-        "AMI": "ami-06f138389ced78a8c"
+        "AMI": "ami-077ec2f7749aefa9e"
     },
     "ap-southeast-4": {
-        "AMI": "ami-06ae04b2e211010d1"
+        "AMI": "ami-0aff946c09b65661c"
     },
     "ap-southeast-5": {
-        "AMI": "ami-02d6911923d6ae64d"
+        "AMI": "ami-0f7c45c86520f9b31"
     },
     "ap-southeast-7": {
-        "AMI": "ami-0edcf41bbf034c7c9"
+        "AMI": "ami-0a145b821757fdac7"
     },
     "ca-central-1": {
-        "AMI": "ami-02e94904388674f70"
+        "AMI": "ami-058187923f48e9f9d"
     },
     "ca-west-1": {
-        "AMI": "ami-0b61897a8c34e2961"
+        "AMI": "ami-06149e11d820d80d6"
     },
     "eu-central-1": {
-        "AMI": "ami-08c120ad621ae3b43"
+        "AMI": "ami-07193b09ec3381584"
     },
     "eu-central-2": {
-        "AMI": "ami-010dc7406c63c065d"
+        "AMI": "ami-05747641bdb290679"
     },
     "eu-north-1": {
-        "AMI": "ami-0b2c59589c03a2396"
+        "AMI": "ami-00b825f36d2bf7301"
     },
     "eu-south-1": {
-        "AMI": "ami-0921ed95090be3504"
+        "AMI": "ami-0cd86695cb720a647"
     },
     "eu-south-2": {
-        "AMI": "ami-02749dd9d0b45805c"
+        "AMI": "ami-0e3112672476c437b"
     },
     "eu-west-1": {
-        "AMI": "ami-0cbeef74534925460"
+        "AMI": "ami-035e7ff2d746ee7e3"
     },
     "eu-west-2": {
-        "AMI": "ami-05dd683254c72505d"
+        "AMI": "ami-0ac81d96ac7a9ed5f"
     },
     "eu-west-3": {
-        "AMI": "ami-0b156ad5971090356"
+        "AMI": "ami-01ac21d8adfd26f50"
     },
     "il-central-1": {
-        "AMI": "ami-05fc4d5dfe6de494c"
+        "AMI": "ami-061d84d9f9be786f9"
     },
     "me-central-1": {
-        "AMI": "ami-0fc6f463b899c237b"
+        "AMI": "ami-083d1736f8fda139c"
     },
     "me-south-1": {
-        "AMI": "ami-029543ea6a20628fd"
+        "AMI": "ami-0a60573d3688d87d1"
     },
     "mx-central-1": {
-        "AMI": "ami-0861c3c7188638e20"
+        "AMI": "ami-013f13cc05c01fd28"
     },
     "sa-east-1": {
-        "AMI": "ami-09491a21b8fba59d0"
+        "AMI": "ami-00622ae2e8e8bda89"
     },
     "us-east-1": {
-        "AMI": "ami-021f2fbd4e0492105"
+        "AMI": "ami-089b86d2f4d27cd98"
     },
     "us-east-2": {
-        "AMI": "ami-0293fbf77b3eb710c"
+        "AMI": "ami-0226dc2af3406c5e5"
     },
     "us-west-1": {
-        "AMI": "ami-0a4357f2c3a18b1d9"
+        "AMI": "ami-0ed57ba0685ce6c59"
     },
     "us-west-2": {
-        "AMI": "ami-0bff72c71351f9b72"
+        "AMI": "ami-0b6310bbffbb4438f"
     }
 }


### PR DESCRIPTION
This is mainly for the test suite.

With this commit, RHEL 9.6 VMs will be launched for the proxy and the RHEL 9 test client. (Was: RHEL 9.5)

The EPEL list has been updated, too.