### PR TITLE
Bumping to 1.5.8

### DIFF
--- a/env/epel.servers
+++ b/env/epel.servers
@@ -1,6 +1,6 @@
 # Dnf/Yum EPEL Servers
-# Updated:        2025-07-07
-# Count:          266
+# Updated:        2025-08-06
+# Count:          262
 # Versions:       4, 5, 6, 7, 8, 9, 10
 # Architectures:  aarch64, armhfp, i386, ppc64, ppc64le, s390x, x86_64
 #
@@ -20,6 +20,7 @@ coresite-atl.mm.fcix.net
 creeperhost.mm.fcix.net
 d2lzkl7pfhq30w.cloudfront.net
 dfw.mirror.rackspace.com
+distrohub.kyiv.ua
 divergentnetworks.mm.fcix.net
 dl.fedoraproject.org
 download-cc-rdu01.fedoraproject.org
@@ -28,11 +29,9 @@ edgeuno-bog2.mm.fcix.net
 epel.grena.ge
 epel.hysing.is
 epel.ip-connect.info
-epel.ip-connect.vn.ua
 epel.mirror.constant.com
 epel.mirror.digitalpacific.com.au
 epel.mirror.liquidtelecom.com
-epel.mirror.liteserver.nl
 epel.mirror.omnilance.com
 epel.mirror.shastacoe.net
 epel.srv.magticom.ge
@@ -43,7 +42,6 @@ fedora-archive.ip-connect.vn.ua
 fedora-archive.mirror.liquidtelecom.com
 fedora-epel.koyanet.lv
 fedora-epel.mirror.iweb.com
-fedora-mirror.cloud.mu
 fedora-mirror02.rbc.ru
 fedora.cs.nctu.edu.tw
 fedora.cu.be
@@ -67,8 +65,7 @@ ftp.cc.uoc.gr
 ftp.cica.es
 ftp.fau.de
 ftp.fi.muni.cz
-ftp.halifax.rwth-aachen.de
-ftp.icm.edu.pl
+ftp.kaist.ac.kr
 ftp.nluug.nl
 ftp.nsc.ru
 ftp.ntua.gr
@@ -126,6 +123,7 @@ mirror.de.leaseweb.net
 mirror.digitalnova.at
 mirror.dogado.de
 mirror.dst.ca
+mirror.ec
 mirror.efect.ro
 mirror.espoch.edu.ec
 mirror.etf.bg.ac.rs
@@ -136,12 +134,10 @@ mirror.fjordos.com
 mirror.fmt-2.serverforge.org
 mirror.freedif.org
 mirror.freethought-internet.co.uk
-mirror.gi.co.id
 mirror.grid.uchicago.edu
 mirror.hnd.cl
 mirror.host.ag
 mirror.hoster.kz
-mirror.hosthink.net
 mirror.hostnet.nl
 mirror.hyperdedic.ru
 mirror.i3d.net
@@ -155,7 +151,6 @@ mirror.karneval.cz
 mirror.lanet.network
 mirror.lax.adaptivedatanetworks.com
 mirror.layeronline.com
-mirror.limda.net
 mirror.linux-ia64.org
 mirror.linux.ec
 mirror.logol.ru
@@ -207,11 +202,11 @@ mirrors.bytes.ua
 mirrors.cat.pdx.edu
 mirrors.chroot.ro
 mirrors.coreix.net
+mirrors.de.sahilister.net
 mirrors.dotsrc.org
 mirrors.fibianet.dk
 mirrors.glesys.net
 mirrors.hosterion.ro
-mirrors.hostico.ro
 mirrors.hostiserver.com
 mirrors.huaweicloud.com
 mirrors.ipserverone.com
@@ -219,7 +214,6 @@ mirrors.ircam.fr
 mirrors.iu13.net
 mirrors.lug.mtu.edu
 mirrors.mit.edu
-mirrors.mivocloud.com
 mirrors.n-ix.net
 mirrors.nav.ro
 mirrors.neterra.net
@@ -228,7 +222,6 @@ mirrors.neusoft.edu.cn
 mirrors.nic.cz
 mirrors.nxthost.com
 mirrors.powernet.com.ru
-mirrors.qlu.edu.cn
 mirrors.rc.rit.edu
 mirrors.sonic.net
 mirrors.tuna.tsinghua.edu.cn
@@ -250,6 +243,7 @@ ohioix.mm.fcix.net
 opencolo.mm.fcix.net
 ord.mirror.rackspace.com
 packages.oit.ncsu.edu
+paducahix.mm.fcix.net
 pubmirror1.math.uh.edu
 pubmirror2.math.uh.edu
 pubmirror3.math.uh.edu
@@ -266,8 +260,10 @@ southfront.mm.fcix.net
 stix.mm.fcix.net
 syd.mirror.rackspace.com
 ucmirror.canterbury.ac.nz
+veronanetworks.mm.fcix.net
 volico.mm.fcix.net
 www.fedora.is
 www.gtlib.gatech.edu
 www.nic.funet.fi
+yxeix.mm.fcix.net
 ziply.mm.fcix.net

--- a/rhproxy.spec
+++ b/rhproxy.spec
@@ -1,6 +1,6 @@
 %global base_version 1.5
-%global patch_version 7
-%global engine_version 1.5.4
+%global patch_version 8
+%global engine_version 1.5.5
 
 Name:           rhproxy
 Version:        %{base_version}.%{patch_version}
@@ -54,6 +54,9 @@ sed -i 's/{{RHPROXY_ENGINE_RELEASE_TAG}}/%{engine_version}/' %{buildroot}/%{_dat
 %{_datadir}/%{name}/download/bin/configure-client.sh.template
 
 %changelog
+* Wed Aug 06 2025 Alberto Bellotti <abellott@redhat.com> - 1.5.8
+- Now pulling the rhproxy-engine container image 1.5.5 from registry.redhat.io
+
 * Mon Jul 07 2025 Alberto Bellotti <abellott@redhat.com> - 1.5.7
 - Now pulling the rhproxy-engine container image 1.5.4 from registry.redhat.io
 


### PR DESCRIPTION
Test build (pulling from quay.io instead of registry.redhat.io)
Pulling in rhproxy-engine 1.5.5