### PR TITLE
update the location of the Zoo test repo

### DIFF
--- a/tests/group_vars/all.yml
+++ b/tests/group_vars/all.yml
@@ -24,6 +24,6 @@ test_3rd_party_repo:
   name: zoo
   description: Zoo from Pulp demo repos
   protocol: https://
-  hostname: repos.fedorapeople.org
-  path_to_repodata: /pulp/pulp/demo_repos/zoo/
+  hostname: fixtures.pulpproject.org
+  path_to_repodata: /rpm-unsigned/
   package: bear


### PR DESCRIPTION
Looks like repos.fedorapeople.org is no longer available. Fortunately, the Zoo demo repo is now available elsewhere. This PR updates the variables based on the repo URL accordingly.