### PR TITLE
feature: Add support for RHEL10 client and Bump to 1.5.9

### DIFF
--- a/download/bin/configure-client.sh.template
+++ b/download/bin/configure-client.sh.template
@@ -114,21 +114,17 @@ function configure_rhc_worker_playbook {
   # Needed as per https://access.redhat.com/solutions/7104932
   if is_rhel 8 9; then
     RHC_WORKER_DIR="/etc/rhc/workers"
-  else
-    RHC_WORKER_DIR="/etc/rhc-worker-playbook"
-  fi
-  RHC_WORKER="rhc-worker-playbook.worker"
-  RHC_WORKER_TOML="${RHC_WORKER_DIR}/${RHC_WORKER}.toml"
-  CFG_PATTERN='env = \[.*"HTTPS_PROXY=".*,.*"HTTP_PROXY=".*\]'
-  CFG='env = ["HTTPS_PROXY=", "https_proxy=", "HTTP_PROXY=", "http_proxy="]'
+    RHC_WORKER="rhc-worker-playbook.worker"
+    RHC_WORKER_TOML="${RHC_WORKER_DIR}/${RHC_WORKER}.toml"
+    CFG_PATTERN='env = \[.*"HTTPS_PROXY=".*,.*"HTTP_PROXY=".*\]'
+    CFG='env = ["HTTPS_PROXY=", "https_proxy=", "HTTP_PROXY=", "http_proxy="]'
 
-  if [ ! -f "${RHC_WORKER_TOML}" ] || ! grep -Eq "${CFG_PATTERN}" "${RHC_WORKER_TOML}"; then
-    echo "Configuring the rhc-worker-playbook worker ..."
-    mkdir -p "${RHC_WORKER_DIR}"
-    echo "${CFG}" >> "${RHC_WORKER_TOML}"
-  fi
+    if [ ! -f "${RHC_WORKER_TOML}" ] || ! grep -Eq "${CFG_PATTERN}" "${RHC_WORKER_TOML}"; then
+      echo "Configuring the rhc-worker-playbook worker ..."
+      mkdir -p "${RHC_WORKER_DIR}"
+      echo "${CFG}" >> "${RHC_WORKER_TOML}"
+    fi
 
-  if is_rhel 8 9; then
     RHC_WORKER_PID="/var/run/rhc/workers/${RHC_WORKER}.pid"
     rm -f "${RHC_WORKER_PID}"
     if is_rhel 9; then

--- a/download/bin/configure-client.sh.template
+++ b/download/bin/configure-client.sh.template
@@ -100,6 +100,7 @@ allow rhcd_t squid_port_t:tcp_socket name_connect;
 }
 
 export RHSM_CONF="/etc/rhsm/rhsm.conf"
+export RHC_WORKER_PLAYBOOK_OVERRIDE_DIR="/etc/systemd/system/com.redhat.Yggdrasil1.Worker1.rhc_worker_playbook.service.d"
 
 function system_service_override_dir {
   if is_rhel 8 9; then
@@ -107,10 +108,6 @@ function system_service_override_dir {
   else
     echo "/etc/systemd/system/yggdrasil.service.d"
   fi
-}
-
-function rhc_worker_playbook_override_dir {
-  echo "/etc/systemd/system/com.redhat.Yggdrasil1.Worker1.rhc_worker_playbook.service.d"
 }
 
 function configure_rhc_worker_playbook {
@@ -198,7 +195,6 @@ Environment=HTTPS_PROXY=http://${PROXY_HOST}:${PROXY_PORT}
 
   # For RHEL10 and later, Override the Environment for the rhc_worker_playbook
   if ! is_rhel 8 9; then
-    RHC_WORKER_PLAYBOOK_OVERRIDE_DIR="$(rhc_worker_playbook_override_dir)"
     mkdir -p "${RHC_WORKER_PLAYBOOK_OVERRIDE_DIR}"
     cat - > "${RHC_WORKER_PLAYBOOK_OVERRIDE_DIR}/override.conf" <<!END!
 [Service]
@@ -227,7 +223,7 @@ elif [ "${SUBCMD}" = "--unconfigure" ]; then
 
   # For RHEL10 and later, Remove the override for the rhc_worker_playbook
   if ! is_rhel 8 9; then
-    rm -f "$(rhc_worker_playbook_override_dir)/override.conf"
+    rm -f "${RHC_WORKER_PLAYBOOK_OVERRIDE_DIR}/override.conf"
   fi
 
   unconfigure_insights_client_proxy_tag

--- a/download/bin/configure-client.sh.template
+++ b/download/bin/configure-client.sh.template
@@ -112,17 +112,19 @@ function system_service_override_dir {
 
 function configure_rhc_worker_playbook {
   # Needed as per https://access.redhat.com/solutions/7104932
-  RHC_WORKER="rhc-worker-playbook.worker"
   if is_rhel 8 9; then
-    RHC_WORKER_TOML="/etc/rhc/workers/${RHC_WORKER}.toml"
+    RHC_WORKER_DIR="/etc/rhc/workers"
   else
-    RHC_WORKER_TOML="/etc/rhc-worker-playbook/${RHC_WORKER}.toml"
+    RHC_WORKER_DIR="/etc/rhc-worker-playbook"
   fi
+  RHC_WORKER="rhc-worker-playbook.worker"
+  RHC_WORKER_TOML="${RHC_WORKER_DIR}/${RHC_WORKER}.toml"
   CFG_PATTERN='env = \[.*"HTTPS_PROXY=".*,.*"HTTP_PROXY=".*\]'
   CFG='env = ["HTTPS_PROXY=", "https_proxy=", "HTTP_PROXY=", "http_proxy="]'
 
   if [ ! -f "${RHC_WORKER_TOML}" ] || ! grep -Eq "${CFG_PATTERN}" "${RHC_WORKER_TOML}"; then
     echo "Configuring the rhc-worker-playbook worker ..."
+    mkdir -p "${RHC_WORKER_DIR}"
     echo "${CFG}" >> "${RHC_WORKER_TOML}"
   fi
 

--- a/download/bin/configure-client.sh.template
+++ b/download/bin/configure-client.sh.template
@@ -106,6 +106,10 @@ function system_service_override_dir {
   fi
 }
 
+function rhc_worker_playbook_override_dir {
+  echo "/etc/systemd/system/com.redhat.Yggdrasil1.Worker1.rhc_worker_playbook.service.d"
+}
+
 function configure_rhc_worker_playbook {
   # Needed as per https://access.redhat.com/solutions/7104932
   RHC_WORKER="rhc-worker-playbook.worker"
@@ -189,6 +193,17 @@ Environment=HTTP_PROXY=http://${PROXY_HOST}:${PROXY_PORT}
 Environment=HTTPS_PROXY=http://${PROXY_HOST}:${PROXY_PORT}
 !END!
 
+  # For RHEL10 and later, Override the Environment for the rhc_worker_playbook
+  if ! is_rhel 8 9; then
+    RHC_WORKER_PLAYBOOK_OVERRIDE_DIR="$(rhc_worker_playbook_override_dir)"
+    mkdir -p "${RHC_WORKER_PLAYBOOK_OVERRIDE_DIR}"
+    cat - > "${RHC_WORKER_PLAYBOOK_OVERRIDE_DIR}/override.conf" <<!END!
+[Service]
+Environment=HTTP_PROXY=http://${PROXY_HOST}:${PROXY_PORT}
+Environment=HTTPS_PROXY=http://${PROXY_HOST}:${PROXY_PORT}
+!END!
+  fi
+
   install_rhcd_selinux_policy
   configure_rhc_worker_playbook
   configure_insights_client_proxy_tag "${PROXY_HOST}"
@@ -205,8 +220,12 @@ elif [ "${SUBCMD}" = "--unconfigure" ]; then
           -e "s/^proxy_port =.*$/proxy_port =-1/" "${RHSM_CONF}"
 
   # Remove the override for the RHC Daemon
-  SERVICE_OVERRIDE_DIR="$(system_service_override_dir)"
-  rm -f "${RHCD_OVERRIDE_DIR}/override.conf"
+  rm -f "$(system_service_override_dir)/override.conf"
+
+  # For RHEL10 and later, Remove the override for the rhc_worker_playbook
+  if ! is_rhel 8 9; then
+    rm -f "$(rhc_worker_playbook_override_dir)/override.conf"
+  fi
 
   unconfigure_insights_client_proxy_tag
   restart_services

--- a/download/bin/configure-client.sh.template
+++ b/download/bin/configure-client.sh.template
@@ -50,9 +50,10 @@ function restart_services {
   if is_rhel 8 9; then
     systemctl restart rhcd
   else
-    if [ "$(systemctl is-enabled yggdrasil)" == "enabled" ]; then
-      systemctl restart yggdrasil
+    if [ "$(systemctl is-enabled yggdrasil)" == "disabled" ]; then
+      systemctl enable yggdrasil
     fi
+    systemctl restart yggdrasil
   fi
 }
 

--- a/download/bin/configure-client.sh.template
+++ b/download/bin/configure-client.sh.template
@@ -50,10 +50,12 @@ function restart_services {
   if is_rhel 8 9; then
     systemctl restart rhcd
   else
-    if [ "$(systemctl is-enabled yggdrasil)" == "disabled" ]; then
-      systemctl enable yggdrasil
+    if subscription-manager identity &> /dev/null; then
+      if [ "$(systemctl is-enabled yggdrasil)" == "disabled" ]; then
+        systemctl enable yggdrasil
+      fi
+      systemctl restart yggdrasil
     fi
-    systemctl restart yggdrasil
   fi
 }
 

--- a/download/bin/configure-client.sh.template
+++ b/download/bin/configure-client.sh.template
@@ -30,17 +30,35 @@ shift
 RHEL_RELEASE=$(uname -r | sed 's/^.*\(el[0-9]\+\).*$/\1/')
 export RHEL_RELEASE
 
+function is_rhel() {
+  for rhel in "$@"
+  do
+    if [ "${RHEL_RELEASE}" == "el${rhel}" ]; then
+      true
+      return
+    fi
+  done
+  false
+  return
+}
+
 function restart_services {
   echo "Restarting Insights Services ..."
   systemctl daemon-reload
   systemctl restart rhsm.service
   systemctl restart rhsmcertd.service
-  systemctl restart rhcd
+  if is_rhel 8 9; then
+    systemctl restart rhcd
+  else
+    if [ "$(systemctl is-enabled yggdrasil)" == "enabled" ]; then
+      systemctl restart yggdrasil
+    fi
+  fi
 }
 
 function install_rhcd_selinux_policy {
   # We don't need to do this for RHEL8
-  if [ "${RHEL_RELEASE}" = "el8" ]; then
+  if is_rhel 8; then
     return
   fi
 
@@ -79,18 +97,23 @@ allow rhcd_t squid_port_t:tcp_socket name_connect;
 }
 
 export RHSM_CONF="/etc/rhsm/rhsm.conf"
-export RHCD_OVERRIDE_DIR="/etc/systemd/system/rhcd.service.d"
+
+function system_service_override_dir {
+  if is_rhel 8 9; then
+    echo "/etc/systemd/system/rhcd.service.d"
+  else
+    echo "/etc/systemd/system/yggdrasil.service.d"
+  fi
+}
 
 function configure_rhc_worker_playbook {
-  # This is only needed on RHEL8 and RHEL9 as per https://access.redhat.com/solutions/7104932
-  if [[ ! "${RHEL_RELEASE}" =~ ^el[89]$ ]]; then
-    return
-  fi
-
+  # Needed as per https://access.redhat.com/solutions/7104932
   RHC_WORKER="rhc-worker-playbook.worker"
-  RHC_WORKER_TOML="/etc/rhc/workers/${RHC_WORKER}.toml"
-  RHC_WORKER_PID="/var/run/rhc/workers/${RHC_WORKER}.pid"
-  RHC_PKGMGR_PID="/var/run/rhc/workers/rhc-package-manager-worker.pid"
+  if is_rhel 8 9; then
+    RHC_WORKER_TOML="/etc/rhc/workers/${RHC_WORKER}.toml"
+  else
+    RHC_WORKER_TOML="/etc/rhc-worker-playbook/${RHC_WORKER}.toml"
+  fi
   CFG_PATTERN='env = \[.*"HTTPS_PROXY=".*,.*"HTTP_PROXY=".*\]'
   CFG='env = ["HTTPS_PROXY=", "https_proxy=", "HTTP_PROXY=", "http_proxy="]'
 
@@ -98,9 +121,14 @@ function configure_rhc_worker_playbook {
     echo "Configuring the rhc-worker-playbook worker ..."
     echo "${CFG}" >> "${RHC_WORKER_TOML}"
   fi
-  rm -f "${RHC_WORKER_PID}"
-  if [ "${RHEL_RELEASE}" = "el9" ]; then
-    rm -f "${RHC_PKGMGR_PID}"
+
+  if is_rhel 8 9; then
+    RHC_WORKER_PID="/var/run/rhc/workers/${RHC_WORKER}.pid"
+    rm -f "${RHC_WORKER_PID}"
+    if is_rhel 9; then
+      RHC_PKGMGR_PID="/var/run/rhc/workers/rhc-package-manager-worker.pid"
+      rm -f "${RHC_PKGMGR_PID}"
+    fi
   fi
 }
 
@@ -153,8 +181,9 @@ if [ "${SUBCMD}" = "--configure" ]; then
           -e "s/^proxy_port =.*$/proxy_port = ${PROXY_PORT}/" "${RHSM_CONF}"
 
   # Override the Environment for the RHC Daemon
-  mkdir -p "${RHCD_OVERRIDE_DIR}"
-  cat - > "${RHCD_OVERRIDE_DIR}/override.conf" <<!END!
+  SERVICE_OVERRIDE_DIR="$(system_service_override_dir)"
+  mkdir -p "${SERVICE_OVERRIDE_DIR}"
+  cat - > "${SERVICE_OVERRIDE_DIR}/override.conf" <<!END!
 [Service]
 Environment=HTTP_PROXY=http://${PROXY_HOST}:${PROXY_PORT}
 Environment=HTTPS_PROXY=http://${PROXY_HOST}:${PROXY_PORT}
@@ -176,6 +205,7 @@ elif [ "${SUBCMD}" = "--unconfigure" ]; then
           -e "s/^proxy_port =.*$/proxy_port =-1/" "${RHSM_CONF}"
 
   # Remove the override for the RHC Daemon
+  SERVICE_OVERRIDE_DIR="$(system_service_override_dir)"
   rm -f "${RHCD_OVERRIDE_DIR}/override.conf"
 
   unconfigure_insights_client_proxy_tag

--- a/env/epel.servers
+++ b/env/epel.servers
@@ -1,6 +1,6 @@
 # Dnf/Yum EPEL Servers
-# Updated:        2025-08-06
-# Count:          262
+# Updated:        2025-08-26
+# Count:          259
 # Versions:       4, 5, 6, 7, 8, 9, 10
 # Architectures:  aarch64, armhfp, i386, ppc64, ppc64le, s390x, x86_64
 #
@@ -50,6 +50,7 @@ fedora.melbourneitmirror.net
 fedora.mirror.garr.it
 fedora.mirror.thegigabit.com
 fedora.mirrorservice.org
+fedora.nic.cz
 fedora.tu-chemnitz.de
 forksystems.mm.fcix.net
 fr2.rpmfind.net
@@ -110,7 +111,6 @@ mirror.cedia.org.ec
 mirror.centos.ikoula.com
 mirror.cherryservers.com
 mirror.chpc.utah.edu
-mirror.cloudhosting.lv
 mirror.cogentco.com
 mirror.compevo.com
 mirror.cpsc.ucalgary.ca
@@ -123,7 +123,6 @@ mirror.de.leaseweb.net
 mirror.digitalnova.at
 mirror.dogado.de
 mirror.dst.ca
-mirror.ec
 mirror.efect.ro
 mirror.espoch.edu.ec
 mirror.etf.bg.ac.rs
@@ -138,6 +137,7 @@ mirror.grid.uchicago.edu
 mirror.hnd.cl
 mirror.host.ag
 mirror.hoster.kz
+mirror.hosthink.net
 mirror.hostnet.nl
 mirror.hyperdedic.ru
 mirror.i3d.net
@@ -157,7 +157,6 @@ mirror.logol.ru
 mirror.lstn.net
 mirror.maeen.sa
 mirror.mangohost.net
-mirror.marwan.ma
 mirror.math.princeton.edu
 mirror.mci-1.serverforge.org
 mirror.netcologne.de
@@ -219,7 +218,6 @@ mirrors.nav.ro
 mirrors.neterra.net
 mirrors.netix.net
 mirrors.neusoft.edu.cn
-mirrors.nic.cz
 mirrors.nxthost.com
 mirrors.powernet.com.ru
 mirrors.rc.rit.edu
@@ -251,7 +249,6 @@ reflector.westga.edu
 rep-epel-il.upress.io
 repo.extreme-ix.org
 repo.ialab.dsu.edu
-repo.jing.rocks
 repos.silknet.com
 ryamer.mm.fcix.net
 sjc.mirror.rackspace.com

--- a/rhproxy.spec
+++ b/rhproxy.spec
@@ -1,6 +1,6 @@
 %global base_version 1.5
-%global patch_version 8
-%global engine_version 1.5.5
+%global patch_version 9
+%global engine_version 1.5.6
 
 Name:           rhproxy
 Version:        %{base_version}.%{patch_version}
@@ -54,6 +54,10 @@ sed -i 's/{{RHPROXY_ENGINE_RELEASE_TAG}}/%{engine_version}/' %{buildroot}/%{_dat
 %{_datadir}/%{name}/download/bin/configure-client.sh.template
 
 %changelog
+* Tue Aug 26 2025 Alberto Bellotti <abellott@redhat.com> - 1.5.9
+- Now pulling the rhproxy-engine container image 1.5.6 from registry.redhat.io
+- Adding support for RHEL10 client systems
+
 * Wed Aug 06 2025 Alberto Bellotti <abellott@redhat.com> - 1.5.8
 - Now pulling the rhproxy-engine container image 1.5.5 from registry.redhat.io
 


### PR DESCRIPTION
- Updated the configure-client.sh script to support configuring RHEL10 client systems.

Fixes: https://issues.redhat.com/browse/IPP-50

## Summary by Sourcery

Add support for RHEL 10 clients and update packaging to release version 1.5.9 with engine 1.5.6

New Features:
- Add support for configuring RHEL 10 client systems

Enhancements:
- Bump spec patch version to 1.5.9 and update rhproxy-engine container image to 1.5.6 from registry.redhat.io

Documentation:
- Update changelog entry for version 1.5.9