### PR TITLE
enable testing RHEL 10 clients

### DIFF
--- a/tests/RHEL10mapping.json
+++ b/tests/RHEL10mapping.json
@@ -1,0 +1,98 @@
+{
+    "af-south-1": {
+        "AMI": "ami-08d2f028c08c32b31"
+    },
+    "ap-east-1": {
+        "AMI": "ami-0db51a5d27b39a82c"
+    },
+    "ap-northeast-1": {
+        "AMI": "ami-0cec7bc91ca5dc5c9"
+    },
+    "ap-northeast-2": {
+        "AMI": "ami-0b4645a46dec10a3f"
+    },
+    "ap-northeast-3": {
+        "AMI": "ami-0063ecf1a0074a979"
+    },
+    "ap-south-1": {
+        "AMI": "ami-095782a7713867262"
+    },
+    "ap-south-2": {
+        "AMI": "ami-01b334e1273acd2f6"
+    },
+    "ap-southeast-1": {
+        "AMI": "ami-02dfe1e313dab6f80"
+    },
+    "ap-southeast-2": {
+        "AMI": "ami-01e7fd1435aa0a8f5"
+    },
+    "ap-southeast-3": {
+        "AMI": "ami-086601e0b586439e6"
+    },
+    "ap-southeast-4": {
+        "AMI": "ami-0d2f11e01e4dbcda8"
+    },
+    "ap-southeast-5": {
+        "AMI": "ami-05dcf018194ef961f"
+    },
+    "ap-southeast-7": {
+        "AMI": "ami-061028506bd3dbbd3"
+    },
+    "ca-central-1": {
+        "AMI": "ami-0653b5fb1744e8da9"
+    },
+    "ca-west-1": {
+        "AMI": "ami-0ff54f3bb461ecb7f"
+    },
+    "eu-central-1": {
+        "AMI": "ami-04702e76d18129db1"
+    },
+    "eu-central-2": {
+        "AMI": "ami-04932597a3abec312"
+    },
+    "eu-north-1": {
+        "AMI": "ami-0e5ff3ba329e647d9"
+    },
+    "eu-south-1": {
+        "AMI": "ami-0c39df6582f223fff"
+    },
+    "eu-south-2": {
+        "AMI": "ami-05cf97e72e1a28df8"
+    },
+    "eu-west-1": {
+        "AMI": "ami-03759974cdb1e9c08"
+    },
+    "eu-west-2": {
+        "AMI": "ami-0863dffee67b0e0a3"
+    },
+    "eu-west-3": {
+        "AMI": "ami-0fe8ae283509e9e7c"
+    },
+    "il-central-1": {
+        "AMI": "ami-04ee361c485b4d430"
+    },
+    "me-central-1": {
+        "AMI": "ami-0e0d9b75399765c0d"
+    },
+    "me-south-1": {
+        "AMI": "ami-00119306807d86cac"
+    },
+    "mx-central-1": {
+        "AMI": "ami-05acfe6ba0cbe1551"
+    },
+    "sa-east-1": {
+        "AMI": "ami-0a690fe719fd4f9e6"
+    },
+    "us-east-1": {
+        "AMI": "ami-07458cd29b6195db0"
+    },
+    "us-east-2": {
+        "AMI": "ami-03e032dea234c9615"
+    },
+    "us-west-1": {
+        "AMI": "ami-07b7bba66b9876f5d"
+    },
+    "us-west-2": {
+        "AMI": "ami-09c0db9d4014bf846"
+    }
+}

--- a/tests/RHEL10mapping_arm64.json
+++ b/tests/RHEL10mapping_arm64.json
@@ -1,0 +1,98 @@
+{
+    "af-south-1": {
+        "AMI": "ami-06d8cd58d5ee0952c"
+    },
+    "ap-east-1": {
+        "AMI": "ami-075ab08b3cc2f25db"
+    },
+    "ap-northeast-1": {
+        "AMI": "ami-00a7a1e324420b317"
+    },
+    "ap-northeast-2": {
+        "AMI": "ami-0d4113136465a04c2"
+    },
+    "ap-northeast-3": {
+        "AMI": "ami-00a44860a3249e19c"
+    },
+    "ap-south-1": {
+        "AMI": "ami-0884173d1259c8f32"
+    },
+    "ap-south-2": {
+        "AMI": "ami-02de70d4fe8af38f5"
+    },
+    "ap-southeast-1": {
+        "AMI": "ami-03e999b70e8d343b9"
+    },
+    "ap-southeast-2": {
+        "AMI": "ami-00d82d2c9b0d35dba"
+    },
+    "ap-southeast-3": {
+        "AMI": "ami-097eb0eb40ee9aeec"
+    },
+    "ap-southeast-4": {
+        "AMI": "ami-00de16df2aa1721d6"
+    },
+    "ap-southeast-5": {
+        "AMI": "ami-06467597211681e7b"
+    },
+    "ap-southeast-7": {
+        "AMI": "ami-0848e73c5330898c7"
+    },
+    "ca-central-1": {
+        "AMI": "ami-0228e2c511ac22e8a"
+    },
+    "ca-west-1": {
+        "AMI": "ami-05faf8170df7ccfb8"
+    },
+    "eu-central-1": {
+        "AMI": "ami-042aceeb078f75998"
+    },
+    "eu-central-2": {
+        "AMI": "ami-01e6ef95445731e27"
+    },
+    "eu-north-1": {
+        "AMI": "ami-0f9145e449a78015a"
+    },
+    "eu-south-1": {
+        "AMI": "ami-0e28ff0cf9edbdc2b"
+    },
+    "eu-south-2": {
+        "AMI": "ami-0020f1a123927bef1"
+    },
+    "eu-west-1": {
+        "AMI": "ami-072159ee740d71553"
+    },
+    "eu-west-2": {
+        "AMI": "ami-0aa97f89d143015ce"
+    },
+    "eu-west-3": {
+        "AMI": "ami-0fceb1a02a3236e42"
+    },
+    "il-central-1": {
+        "AMI": "ami-0f222f743ad13f8cd"
+    },
+    "me-central-1": {
+        "AMI": "ami-0ccdb64670905a2a1"
+    },
+    "me-south-1": {
+        "AMI": "ami-0c585a1880578b5c9"
+    },
+    "mx-central-1": {
+        "AMI": "ami-0c384482d830fc0c0"
+    },
+    "sa-east-1": {
+        "AMI": "ami-052f630efcb708fd6"
+    },
+    "us-east-1": {
+        "AMI": "ami-04826a0267ca9146a"
+    },
+    "us-east-2": {
+        "AMI": "ami-0a23218de7b568324"
+    },
+    "us-west-1": {
+        "AMI": "ami-0baeb1569c9651b5d"
+    },
+    "us-west-2": {
+        "AMI": "ami-0bb0d15fbefa4221b"
+    }
+}

--- a/tests/client/main.yml
+++ b/tests/client/main.yml
@@ -9,10 +9,12 @@
     failed_when: get_ns.stdout_lines|length == 0
     tags: build_firewall
 
-  - name: forbid locally-initiated outgoing connections
-    # do this in one shell command; the first command alone would cut the system off
-    # you may experience a short blip anyway, IOW, this task may take longer than usual
-    shell: "iptables -P OUTPUT DROP ; iptables -A OUTPUT -m state --state RELATED,ESTABLISHED -j ACCEPT"
+  - name: clear existing rules in the OUTPUT chain
+    command: "iptables -F OUTPUT"
+    tags: build_firewall
+
+  - name: allow outgoing traffic for established and related connections
+    command: "iptables -A OUTPUT -m state --state RELATED,ESTABLISHED -j ACCEPT"
     tags: build_firewall
 
   - name: allow DNS lookups
@@ -29,6 +31,10 @@
     when: "inventory_hostname.endswith('amazonaws.com')"
     tags: build_firewall
 
+  - name: drop all other outgoing traffic at the end of the chain
+    command: "iptables -A OUTPUT -j DROP"
+    tags: build_firewall
+
   - name: check if direct connection to an allowed remote host fails (times out due to the firewall)
     command: "curl -m 5 https://{{ test_good_host }}/"
     register: curl_direct
@@ -37,10 +43,12 @@
     tags: direct_connect
 
   - name: check if connection to an unauthorized remote host through the proxy is denied
+    vars:
+      curl_error: "{{ 'Received HTTP code 404 from proxy after CONNECT' if ansible_distribution_major_version|int <= 9 else 'CONNECT tunnel failed, response 404' }}"
     command: "curl -L -x http://{{ server }}:3128 https://{{ test_bad_host }}/"
     register: curl_proxy_bad_host
     changed_when: false
-    failed_when: "curl_proxy_bad_host.rc != 56 or 'Received HTTP code 404 from proxy after CONNECT' not in curl_proxy_bad_host.stderr"
+    failed_when: "curl_proxy_bad_host.rc != 56 or curl_error not in curl_proxy_bad_host.stderr"
     tags: proxy_connect
 
   - name: download the helper script

--- a/tests/create-cf-stack.py
+++ b/tests/create-cf-stack.py
@@ -28,6 +28,8 @@ argparser.add_argument('--cli8', help='number of RHEL8 clients', type=int, defau
 argparser.add_argument('--cli8-arch', help='RHEL 8 clients\' architectures (comma-separated list)', default='x86_64', metavar='ARCH')
 argparser.add_argument('--cli9', help='number of RHEL9 clients', type=int, default=1)
 argparser.add_argument('--cli9-arch', help='RHEL 9 clients\' architectures (comma-separated list)', default='x86_64', metavar='ARCH')
+argparser.add_argument('--cli10', help='number of RHEL10 clients', type=int, default=1)
+argparser.add_argument('--cli10-arch', help='RHEL 10 clients\' architectures (comma-separated list)', default='x86_64', metavar='ARCH')
 argparser.add_argument('--server-arch', default="x86_64", help='use this architecture for the proxy server')
 argparser.add_argument('--input-conf', default="/etc/ec2.yaml", help='use supplied yaml config file')
 argparser.add_argument('--output-conf', help='output file')
@@ -45,8 +47,9 @@ argparser.add_argument('--novpc', help='do not use VPC, use EC2 Classic', action
 
 argparser.add_argument('--ami-8-override', help='RHEL 8 AMI ID to override the mapping', metavar='ID')
 argparser.add_argument('--ami-9-override', help='RHEL 9 AMI ID to override the mapping', metavar='ID')
+argparser.add_argument('--ami-10-override', help='RHEL 10 AMI ID to override the mapping', metavar='ID')
 argparser.add_argument('--ami-8-arm64-override', help='RHEL 8 ARM64 AMI ID to override the mapping', metavar='ID')
-argparser.add_argument('--ami-9-arm64-override', help='RHEL 9 ARM64 AMI ID to override the mapping', metavar='ID')
+argparser.add_argument('--ami-10-arm64-override', help='RHEL 10 ARM64 AMI ID to override the mapping', metavar='ID')
 argparser.add_argument('--ansible-ssh-extra-args', help='Extra arguments for SSH connections established by Ansible', metavar='ARGS')
 argparser.add_argument('--key-pair-name', help='the name of the key pair in the given AWS region, if your local user name differs and SSH configuraion is undefined in the yaml config file')
 
@@ -106,7 +109,8 @@ proxy_os = "RHEL9"
 json_dict['Description'] = "Insights proxy stack"
 
 json_dict['Mappings'] = {u'RHEL8': {args.region: {}},
-                         u'RHEL9': {args.region: {}}}
+                         u'RHEL9': {args.region: {}},
+                         u'RHEL10': {args.region: {}}}
 
 try:
     if args.ami_8_override:
@@ -122,6 +126,13 @@ try:
         with open("RHEL9mapping.json") as mjson:
             rhel9mapping = json.load(mjson)
             json_dict['Mappings']['RHEL9'] = rhel9mapping
+
+    if args.ami_10_override:
+        json_dict['Mappings']['RHEL10'][args.region]['AMI'] = args.ami_10_override
+    else:
+        with open("RHEL10mapping.json") as mjson:
+            rhel10mapping = json.load(mjson)
+            json_dict['Mappings']['RHEL10'] = rhel10mapping
 
 except Exception as e:
     sys.stderr.write("Got '%s' error \n" % e)
@@ -176,8 +187,8 @@ json_dict['Resources']["proxy"] = \
                u'Type': u'AWS::EC2::Instance'}
 
 # clients
-os_dict = {8: "RHEL8", 9: "RHEL9"}
-for i in (8, 9):
+os_dict = {8: "RHEL8", 9: "RHEL9", 10: "RHEL10"}
+for i in (8, 9, 10):
     num_cli_ver = args.__getattribute__("cli%i" % i)
     if num_cli_ver:
         os = os_dict[i]
@@ -205,6 +216,8 @@ for i in (8, 9):
                     image_id = args.ami_8_arm64_override
                 elif i == 9 and args.ami_9_arm64_override:
                     image_id = args.ami_9_arm64_override
+                elif i == 10 and args.ami_10_arm64_override:
+                    image_id = args.ami_10_arm64_override
                 else:
                     with open("RHEL%smapping_%s.json" % (i, cli_arch)) as mjson:
                        image_ids =  json.load(mjson)

--- a/tests/rhc/main.yml
+++ b/tests/rhc/main.yml
@@ -26,6 +26,34 @@
     when: inventory_hostname in groups['CLI']
     tags: rhc
 
+  - name: block for rhc as the command for everything
+    block:
+      - name: temporarily disconnect from Red Hat services
+        command: rhc disconnect
+
+      - name: check the status to make sure the disconnection happened
+        command: rhc status
+        register: client_status_2
+        failed_when: client_status_2.rc == 0
+
+      - name: reconnect using rhc
+        command: rhc connect -u {{ rh_username }} -p '{{ rh_password }}'
+
+      - name: check status to make sure everything was restored
+        command: rhc status
+        register: client_status_3
+
+      - name: analyze the output
+        assert:
+          that:
+            - "'Connected to Red Hat Subscription Management' in client_status_3.stdout"
+            - "'Connected to Red Hat Insights' in client_status_3.stdout"
+            - "'The yggdrasil service is active' in client_status_3.stdout"
+          success_msg: OK
+          fail_msg: "{{ client_status_3.stdout_lines }}"
+    when: inventory_hostname in groups['CLI'] and ansible_distribution_major_version|int == 10
+    tags: rhc
+
   - name: block for server tasks
     block:
       - name: check the server log

--- a/tests/setup/main.yml
+++ b/tests/setup/main.yml
@@ -23,6 +23,17 @@
       state: present
     tags: build_firewall
 
+  - name: check if rebooting is needed
+    command: needs-restarting -r
+    register: needs_restarting
+    failed_when: needs_restarting.rc not in [0, 1]
+    tags: build_firewall
+
+  - name: reboot after installing the firewall, if the kernel was updated at the same time
+    reboot:
+    when: needs_restarting.rc == 1
+    tags: build_firewall
+
   - name: make sure the playbook package is installed on the clients
     package:
       name: rhc-worker-playbook


### PR DESCRIPTION
This PR adds support for RHEL 10 clients to the Insights proxy test suite.

In particular:

-  a RHEL 10 client is now always launched by default; this can be avoided, or the architecture can be changed to arm64
- there was an issue where my RHEL 10 client remained unreachable after the firewall rules were applied. I thought RHEL 10 was too fast in processing the task to "drop everything in one iptables invocation and immediately allow established and related connections in the next iptables invocations", but that wasn't the real root cause. The real root cause was the fact that a newer kernel version was installed when the iptables RPM was installed on this RHEL 10 VM. The shell showed this error: Extension state revision 0 not supported, missing kernel module. So the solution was the reboot the system if necessary, but I decided to reorder the iptables rules anyway, as suggested by AI.
- the ouput from curl is different on RHEL 10 when trying to use the proxy to fetch content from an unauthorized host, so the check had to be modified
- a test has added to see if "rhc connect" is all you need on RHEL 10