### PR TITLE
simplify client loops

### DIFF
--- a/env/epel.servers
+++ b/env/epel.servers
@@ -1,6 +1,6 @@
 # Dnf/Yum EPEL Servers
-# Updated:        2025-09-01
-# Count:          259
+# Updated:        2025-09-05
+# Count:          258
 # Versions:       4, 5, 6, 7, 8, 9, 10
 # Architectures:  aarch64, armhfp, i386, ppc64, ppc64le, s390x, x86_64
 #
@@ -20,7 +20,6 @@ coresite-atl.mm.fcix.net
 creeperhost.mm.fcix.net
 d2lzkl7pfhq30w.cloudfront.net
 dfw.mirror.rackspace.com
-distrohub.kyiv.ua
 divergentnetworks.mm.fcix.net
 dl.fedoraproject.org
 download-cc-rdu01.fedoraproject.org

--- a/tests/create-cf-stack.py
+++ b/tests/create-cf-stack.py
@@ -116,28 +116,16 @@ json_dict['Mappings'] = {u'RHEL8': {args.region: {}},
                          u'RHEL9': {args.region: {}},
                          u'RHEL10': {args.region: {}}}
 
+cli_os_versions = (8, 9, 10)
+
 try:
-    if args.ami_8_override:
-        json_dict['Mappings']['RHEL8'][args.region]['AMI'] = args.ami_8_override
-    else:
-        with open("RHEL8mapping.json") as mjson:
-            rhel8mapping = json.load(mjson)
-            json_dict['Mappings']['RHEL8'] = rhel8mapping
-
-    if args.ami_9_override:
-        json_dict['Mappings']['RHEL9'][args.region]['AMI'] = args.ami_9_override
-    else:
-        with open("RHEL9mapping.json") as mjson:
-            rhel9mapping = json.load(mjson)
-            json_dict['Mappings']['RHEL9'] = rhel9mapping
-
-    if args.ami_10_override:
-        json_dict['Mappings']['RHEL10'][args.region]['AMI'] = args.ami_10_override
-    else:
-        with open("RHEL10mapping.json") as mjson:
-            rhel10mapping = json.load(mjson)
-            json_dict['Mappings']['RHEL10'] = rhel10mapping
-
+    for i in cli_os_versions:
+        if override := args.__getattribute__(f"ami_{i}_override"):
+            json_dict["Mappings"][f"RHEL{i}"][args.region]["AMI"] = override
+        else:
+            with open(f"RHEL{i}mapping.json") as mjson:
+                mapping = json.load(mjson)
+                json_dict["Mappings"][f"RHEL{i}"] = mapping
 except Exception as e:
     sys.stderr.write("Got '%s' error \n" % e)
     sys.exit(1)
@@ -191,14 +179,12 @@ json_dict['Resources']["proxy"] = \
                u'Type': u'AWS::EC2::Instance'}
 
 # clients
-os_dict = {8: "RHEL8", 9: "RHEL9", 10: "RHEL10"}
-for i in (8, 9, 10):
-    num_cli_ver = args.__getattribute__("cli%i" % i)
-    if num_cli_ver:
-        os = os_dict[i]
+for i in cli_os_versions:
+    if num_cli_ver := args.__getattribute__(f"cli{i}"):
+        os = f"RHEL{i}"
         for j in range(1, num_cli_ver + 1):
             try:
-                cli_arch = args.__getattribute__("cli%i_arch" % i).split(",")[j-1]
+                cli_arch = args.__getattribute__(f"cli{i}_arch").split(",")[j-1]
                 if not cli_arch:
                     cli_arch = "x86_64"
             except (AttributeError, IndexError):


### PR DESCRIPTION
Resolves https://github.com/RedHatInsights/rhproxy/issues/57.

## Summary by Sourcery

Simplify the AMI mapping and client instantiation logic by iterating over OS versions instead of repeating code for each major version

Enhancements:
- Consolidate AMI override and mapping file loading into a single loop over OS versions using assignment expressions and f-strings
- Generalize client loop logic to iterate over OS versions and dynamically access CLI arguments with f-strings