### PR TITLE
Updating RPM to 1.5.10

### DIFF
--- a/rhproxy.spec
+++ b/rhproxy.spec
@@ -1,6 +1,6 @@
 %global base_version 1.5
-%global patch_version 9
-%global engine_version 1.5.6
+%global patch_version 10
+%global engine_version 1.5.7
 
 Name:           rhproxy
 Version:        %{base_version}.%{patch_version}
@@ -54,6 +54,10 @@ sed -i 's/{{RHPROXY_ENGINE_RELEASE_TAG}}/%{engine_version}/' %{buildroot}/%{_dat
 %{_datadir}/%{name}/download/bin/configure-client.sh.template
 
 %changelog
+* Thu Oct 02 2025 Alberto Bellotti <abellott@redhat.com> - 1.5.10
+- Now pulling the rhproxy-engine container image 1.5.7 from registry.redhat.io
+- Fixed configuration script to also update the insights-client.conf file
+
 * Tue Aug 26 2025 Alberto Bellotti <abellott@redhat.com> - 1.5.9
 - Now pulling the rhproxy-engine container image 1.5.6 from registry.redhat.io
 - Adding support for RHEL10 client systems


### PR DESCRIPTION
- Now pulling the rhproxy-engine container image 1.5.7 from registry.redhat.io
- Fixed configuration script to also update the insights-client.conf file