### PR TITLE
Bumping rhproxy to 1.5.15

### DIFF
--- a/env/epel.servers
+++ b/env/epel.servers
@@ -1,6 +1,6 @@
 # Dnf/Yum EPEL Servers
-# Updated:        2026-03-17
-# Count:          243
+# Updated:        2026-04-22
+# Count:          237
 # Versions:       4, 5, 6, 7, 8, 9, 10
 # Architectures:  aarch64, armhfp, i386, ppc64, ppc64le, s390x, x86_64
 #
@@ -19,11 +19,11 @@ codingflyboy.mm.fcix.net
 cofractal-ewr.mm.fcix.net
 cofractal-sea.mm.fcix.net
 coresite-atl.mm.fcix.net
-creeperhost.mm.fcix.net
 d2lzkl7pfhq30w.cloudfront.net
 de.mirrors.cicku.me
 dfw.mirror.rackspace.com
 distrohub.kyiv.ua
+divergentnetworks.mm.fcix.net
 dl.fedoraproject.org
 edgeuno-bog2.mm.fcix.net
 epel.grena.ge
@@ -31,6 +31,7 @@ epel.hysing.is
 epel.ip-connect.info
 epel.ip-connect.vn.ua
 epel.mirror.constant.com
+epel.mirror.globo.tech
 epel.mirror.liquidtelecom.com
 epel.mirror.liteserver.nl
 epel.mirror.omnilance.com
@@ -68,7 +69,6 @@ ftp.cica.es
 ftp.fau.de
 ftp.kaist.ac.kr
 ftp.linux.edu.lv
-ftp.lysator.liu.se
 ftp.nsc.ru
 ftp.rediris.es
 ftp.riken.jp
@@ -76,7 +76,6 @@ ftp.sh.cvut.cz
 ftp.uni-bayreuth.de
 ftp.uni-kl.de
 ftp.uni-stuttgart.de
-ftp.upjs.sk
 ftp.yz.yamagata-u.ac.jp
 gb.mirrors.cicku.me
 ge.mirror.cloud9.ge
@@ -85,7 +84,6 @@ gsl-syd.mm.fcix.net
 hkg.mirror.rackspace.com
 iad.mirror.rackspace.com
 insect.mm.fcix.net
-ipng.mm.fcix.net
 irltoolkit.mm.fcix.net
 it1.mirror.vhosting-it.com
 it2.mirror.vhosting-it.com
@@ -101,6 +99,7 @@ mirror.23m.com
 mirror.aarnet.edu.au
 mirror.accum.se
 mirror.airenetworks.es
+mirror.akl-2.serverforge.org
 mirror.alwyzon.net
 mirror.ams-1.serverforge.org
 mirror.bahnhof.net
@@ -109,7 +108,6 @@ mirror.centos.ikoula.com
 mirror.cherryservers.com
 mirror.citrahost.com
 mirror.cogentco.com
-mirror.colocenter.nl
 mirror.compevo.com
 mirror.cpsc.ucalgary.ca
 mirror.cs.princeton.edu
@@ -133,8 +131,6 @@ mirror.grid.uchicago.edu
 mirror.hnd.cl
 mirror.host.ag
 mirror.hoster.kz
-mirror.hosthink.net
-mirror.hostnet.nl
 mirror.i3d.net
 mirror.imt-systems.com
 mirror.in2p3.fr
@@ -183,14 +179,12 @@ mirror.vsys.host
 mirror.wd6.net
 mirror.xenyth.net
 mirror.yandex.ru
-mirror.yer.az
 mirror.za.abantu.cloud
 mirrors.20i.com
 mirrors.bfsu.edu.cn
 mirrors.cat.pdx.edu
 mirrors.chroot.ro
 mirrors.coreix.net
-mirrors.dotsrc.org
 mirrors.fibianet.dk
 mirrors.glesys.net
 mirrors.hosterion.ro
@@ -207,14 +201,12 @@ mirrors.nav.ro
 mirrors.neterra.net
 mirrors.netix.net
 mirrors.nxthost.com
-mirrors.qlu.edu.cn
 mirrors.rc.rit.edu
 mirrors.sonic.net
 mirrors.tuna.tsinghua.edu.cn
 mirrors.ukfast.co.uk
 mirrors.uni-ruse.bg
 mirrors.upr.edu
-mirrors.vcea.wsu.edu
 mirrors.wcupa.edu
 mirrors.xmission.com
 mirrors.xtom.de
@@ -223,6 +215,7 @@ muug.ca
 nl.mirrors.cicku.me
 nnenix.mm.fcix.net
 nocix.mm.fcix.net
+nullroute.mm.fcix.net
 ohioix.mm.fcix.net
 opencolo.mm.fcix.net
 ord.mirror.rackspace.com
@@ -242,6 +235,7 @@ southfront.mm.fcix.net
 stix.mm.fcix.net
 syd.mirror.rackspace.com
 us.mirrors.cicku.me
+veronanetworks.mm.fcix.net
 volico.mm.fcix.net
 www.fedora.is
 www.gtlib.gatech.edu

--- a/rhproxy.spec
+++ b/rhproxy.spec
@@ -1,5 +1,5 @@
-%global rpm_version 1.5.14
-%global engine_version 1.5.11
+%global rpm_version 1.5.15
+%global engine_version 1.5.12
 
 Name:           rhproxy
 Version:        %{rpm_version}
@@ -53,6 +53,9 @@ sed -i 's/{{RHPROXY_ENGINE_RELEASE_TAG}}/%{engine_version}/' %{buildroot}/%{_dat
 %{_datadir}/%{name}/download/bin/configure-client.sh.template
 
 %changelog
+* Wed Apr 22 2026 Alberto Bellotti <abellott@redhat.com> - 1.5.15
+- Now pulling the rhproxy-engine container image 1.5.12 from registry.redhat.io
+
 * Mon Mar 16 2026 Alberto Bellotti <abellott@redhat.com> - 1.5.14
 - Now pulling the rhproxy-engine container image 1.5.11 from registry.redhat.io
 


### PR DESCRIPTION
- Updating Insights proxy RPM to 1.5.15
- Now pulling the rhproxy-engine container version 1.5.12
- Updating the env/epel.servers list

## Summary by Sourcery

Bump rhproxy packaging and engine container versions and refresh associated environment configuration.

Enhancements:
- Update rhproxy RPM version to 1.5.15 and rhproxy-engine container image to 1.5.12.

Build:
- Adjust RPM spec metadata and changelog for the new rhproxy and engine versions.

Chores:
- Refresh the env/epel.servers configuration list.