### PR TITLE
refresh AMI IDs for 10.2 and 9.8, change the expected output from rhc…

### DIFF
--- a/tests/RHEL10mapping.json
+++ b/tests/RHEL10mapping.json
@@ -1,104 +1,98 @@
 {
     "af-south-1": {
-        "AMI": "ami-06fe541adb3555cf6"
+        "AMI": "ami-0ea5f6203aeacabf3"
     },
     "ap-east-1": {
-        "AMI": "ami-004a93b78b2a17b73"
+        "AMI": "ami-0d872527120641d9d"
     },
     "ap-east-2": {
-        "AMI": "ami-022400c94a0dd4d7b"
+        "AMI": "ami-0de44c55ba5bfbf13"
     },
     "ap-northeast-1": {
-        "AMI": "ami-002b5ab70b48eeacd"
+        "AMI": "ami-08f50e9880b8b105e"
     },
     "ap-northeast-2": {
-        "AMI": "ami-048d462116f914f2e"
+        "AMI": "ami-08ee6053c79da3fcc"
     },
     "ap-northeast-3": {
-        "AMI": "ami-0906171c0b74f5fde"
+        "AMI": "ami-0b05c63ab0afb20ac"
     },
     "ap-south-1": {
-        "AMI": "ami-05afa1f666ede8050"
+        "AMI": "ami-0fbe915c156521ee2"
     },
     "ap-south-2": {
-        "AMI": "ami-08e1fecad5486267c"
+        "AMI": "ami-0f9086d47a44a89cd"
     },
     "ap-southeast-1": {
-        "AMI": "ami-0139455fb51188c1a"
+        "AMI": "ami-0d3e9a1bef9f24b1f"
     },
     "ap-southeast-2": {
-        "AMI": "ami-04758f4b05bf4e350"
+        "AMI": "ami-0753b3c25611b31a0"
     },
     "ap-southeast-3": {
-        "AMI": "ami-016432985d48a6d23"
+        "AMI": "ami-019f9ce8242fd5455"
     },
     "ap-southeast-4": {
-        "AMI": "ami-0ffea4950472c42ac"
+        "AMI": "ami-0e057a74cddd76d1b"
     },
     "ap-southeast-5": {
-        "AMI": "ami-0ee3847e09c4e7d2d"
+        "AMI": "ami-0100e5bef8031a0b7"
     },
     "ap-southeast-6": {
-        "AMI": "ami-0b263e4324982c958"
+        "AMI": "ami-06a4b379f6aac3328"
     },
     "ap-southeast-7": {
-        "AMI": "ami-0d94e4c6e10588362"
+        "AMI": "ami-09e900e7bffc0321b"
     },
     "ca-central-1": {
-        "AMI": "ami-025df7e521a63b43f"
+        "AMI": "ami-02024f95b5b27176e"
     },
     "ca-west-1": {
-        "AMI": "ami-04c708c8fdc84c199"
+        "AMI": "ami-0eb8d7497ad86140a"
     },
     "eu-central-1": {
-        "AMI": "ami-0b529038b87350107"
+        "AMI": "ami-0d55a45fdefc6cdc6"
     },
     "eu-central-2": {
-        "AMI": "ami-003d5e2c14601950d"
+        "AMI": "ami-012f8c4116f802f98"
     },
     "eu-north-1": {
-        "AMI": "ami-09318c1d206e681bb"
+        "AMI": "ami-0eb2e9db873545551"
     },
     "eu-south-1": {
-        "AMI": "ami-02bc5484611aa5630"
+        "AMI": "ami-02aac05fc4d689729"
     },
     "eu-south-2": {
-        "AMI": "ami-0b8555984c3ad7957"
+        "AMI": "ami-0a7bba5acf6fb2a13"
     },
     "eu-west-1": {
-        "AMI": "ami-0865308cacacaa32e"
+        "AMI": "ami-08f8eaba113e7968e"
     },
     "eu-west-2": {
-        "AMI": "ami-08ff305da5a3d3347"
+        "AMI": "ami-0765e0d00571193d4"
     },
     "eu-west-3": {
-        "AMI": "ami-0c52b4755fb753941"
+        "AMI": "ami-024bca1191f286f7a"
     },
     "il-central-1": {
-        "AMI": "ami-0c8e3c55c172ee8bd"
-    },
-    "me-central-1": {
-        "AMI": "ami-0dfc10d05b5cd5601"
-    },
-    "me-south-1": {
-        "AMI": "ami-02b2428fb04fc4f89"
+        "AMI": "ami-09a9c3b3158145fdd"
     },
     "mx-central-1": {
-        "AMI": "ami-08cfc0b1cf343b93f"
+        "AMI": "ami-029849fc435696ca8"
     },
     "sa-east-1": {
-        "AMI": "ami-01217b0348f506e72"
+        "AMI": "ami-0e16c14ffc3f334fa"
     },
     "us-east-1": {
-        "AMI": "ami-0e0864508009f1729"
+        "AMI": "ami-08cce14972119d7a2"
     },
     "us-east-2": {
-        "AMI": "ami-0886072325c42ee75"
+        "AMI": "ami-0af8c441e6150bf23"
     },
     "us-west-1": {
-        "AMI": "ami-0cb37ad13b0e80353"
+        "AMI": "ami-08ec7116a7457ca99"
     },
     "us-west-2": {
-        "AMI": "ami-0d050139e29e6019c"
+        "AMI": "ami-0b0a2866db75d5e13"
     }
 }

--- a/tests/RHEL10mapping_arm64.json
+++ b/tests/RHEL10mapping_arm64.json
@@ -1,104 +1,98 @@
 {
     "af-south-1": {
-        "AMI": "ami-06c593aa371085e1f"
+        "AMI": "ami-0f27ec7e708d84681"
     },
     "ap-east-1": {
-        "AMI": "ami-0f76f54a85843c1e4"
+        "AMI": "ami-017e9e3bc8a86e72e"
     },
     "ap-east-2": {
-        "AMI": "ami-027a09f946aebfadd"
+        "AMI": "ami-02d8dc4e421e35069"
     },
     "ap-northeast-1": {
-        "AMI": "ami-0017de14936629c41"
+        "AMI": "ami-01b59287d16a7f8b1"
     },
     "ap-northeast-2": {
-        "AMI": "ami-09bc6e4297988c16f"
+        "AMI": "ami-0cba984d7c6482121"
     },
     "ap-northeast-3": {
-        "AMI": "ami-059f7b10076374f03"
+        "AMI": "ami-029afec79805f913b"
     },
     "ap-south-1": {
-        "AMI": "ami-053b847c6186373f4"
+        "AMI": "ami-064e4bbc3eb365e00"
     },
     "ap-south-2": {
-        "AMI": "ami-088ddd5b27082b5d3"
+        "AMI": "ami-0cc5eff811efbe336"
     },
     "ap-southeast-1": {
-        "AMI": "ami-0afaf1d0fe56bd5b8"
+        "AMI": "ami-0438ec5dbefb63b8d"
     },
     "ap-southeast-2": {
-        "AMI": "ami-025257254144f9927"
+        "AMI": "ami-0de44ab6df439138b"
     },
     "ap-southeast-3": {
-        "AMI": "ami-08e2a42fcdf56ab37"
+        "AMI": "ami-0e3ef7a0e2393ff12"
     },
     "ap-southeast-4": {
-        "AMI": "ami-0cba7743ac120b5ad"
+        "AMI": "ami-005365e29d426cb92"
     },
     "ap-southeast-5": {
-        "AMI": "ami-0c757ed9008a2a546"
+        "AMI": "ami-0278c2d52f31093ba"
     },
     "ap-southeast-6": {
-        "AMI": "ami-03ed729ceddb0a864"
+        "AMI": "ami-0cac7f41e333abec9"
     },
     "ap-southeast-7": {
-        "AMI": "ami-0de4eb8b0485f4ad0"
+        "AMI": "ami-020f86feaa4a60885"
     },
     "ca-central-1": {
-        "AMI": "ami-0ded491717643acb0"
+        "AMI": "ami-00558c890ca01ff74"
     },
     "ca-west-1": {
-        "AMI": "ami-0043571ecc3c058eb"
+        "AMI": "ami-0f4bfaeabce70082a"
     },
     "eu-central-1": {
-        "AMI": "ami-0809955999e24cfdc"
+        "AMI": "ami-0c619c1c520bda4bf"
     },
     "eu-central-2": {
-        "AMI": "ami-08b53eebfd9c7fbad"
+        "AMI": "ami-04ddad808900b83f1"
     },
     "eu-north-1": {
-        "AMI": "ami-06d941e2c72f694d8"
+        "AMI": "ami-05c3285469bd7f105"
     },
     "eu-south-1": {
-        "AMI": "ami-0bbfa48611f340400"
+        "AMI": "ami-0338ee5eefb24e8c5"
     },
     "eu-south-2": {
-        "AMI": "ami-09edbafa5cb042dfe"
+        "AMI": "ami-04d5529fdad12de40"
     },
     "eu-west-1": {
-        "AMI": "ami-0bf3e3bc2f42dd0e3"
+        "AMI": "ami-026fed7d5b21830d3"
     },
     "eu-west-2": {
-        "AMI": "ami-03c0a76bb6ad1ffe7"
+        "AMI": "ami-077496810bc61e633"
     },
     "eu-west-3": {
-        "AMI": "ami-06976b600affc5c2e"
+        "AMI": "ami-0024bc980fd1e0eff"
     },
     "il-central-1": {
-        "AMI": "ami-04a8eb3bc449ed9dc"
-    },
-    "me-central-1": {
-        "AMI": "ami-0869067798b35161b"
-    },
-    "me-south-1": {
-        "AMI": "ami-08322bb80121de10a"
+        "AMI": "ami-02864b27bd1f9aa78"
     },
     "mx-central-1": {
-        "AMI": "ami-0f3edac86ae466dca"
+        "AMI": "ami-01677fa5ad76d9998"
     },
     "sa-east-1": {
-        "AMI": "ami-09c4aca12169830da"
+        "AMI": "ami-09453562475d0c44f"
     },
     "us-east-1": {
-        "AMI": "ami-03d9eec0fe95df48d"
+        "AMI": "ami-02c8100169a9dbfc8"
     },
     "us-east-2": {
-        "AMI": "ami-0d40b706cdc82bb85"
+        "AMI": "ami-04b3df0199974ed55"
     },
     "us-west-1": {
-        "AMI": "ami-01eabdfe30cbc38c9"
+        "AMI": "ami-0386784ad3fbfa41c"
     },
     "us-west-2": {
-        "AMI": "ami-00326382229b9a66e"
+        "AMI": "ami-040f2503a3810cecf"
     }
 }

--- a/tests/RHEL8mapping.json
+++ b/tests/RHEL8mapping.json
@@ -1,104 +1,98 @@
 {
     "af-south-1": {
-        "AMI": "ami-05f0344d636d172e0"
+        "AMI": "ami-0197b1dae91f6a036"
     },
     "ap-east-1": {
-        "AMI": "ami-0e9d06c457f179641"
+        "AMI": "ami-04c177decb8020aab"
     },
     "ap-east-2": {
-        "AMI": "ami-0b28fc581b4ac7a4f"
+        "AMI": "ami-0d4f34c3d5f140a02"
     },
     "ap-northeast-1": {
-        "AMI": "ami-014aef0d00443a9ea"
+        "AMI": "ami-0b94bb8f45a4354be"
     },
     "ap-northeast-2": {
-        "AMI": "ami-0695617b4633e7c28"
+        "AMI": "ami-017d7b3a2ad913a56"
     },
     "ap-northeast-3": {
-        "AMI": "ami-0d1ece663b0f7a04e"
+        "AMI": "ami-08cd1a560d8731ab5"
     },
     "ap-south-1": {
-        "AMI": "ami-07507024a7a2d04fc"
+        "AMI": "ami-0437ea36523357d26"
     },
     "ap-south-2": {
-        "AMI": "ami-09cf484a5532d88cc"
+        "AMI": "ami-0041aa07dc850a4bd"
     },
     "ap-southeast-1": {
-        "AMI": "ami-0c76073bd64bf4f15"
+        "AMI": "ami-068007ba48af45570"
     },
     "ap-southeast-2": {
-        "AMI": "ami-0006842f9513bd422"
+        "AMI": "ami-08e930b58d822eadf"
     },
     "ap-southeast-3": {
-        "AMI": "ami-0550882f64773fee3"
+        "AMI": "ami-02ef6260b6eb98c42"
     },
     "ap-southeast-4": {
-        "AMI": "ami-06c47222c19927678"
+        "AMI": "ami-06f9202db5764b3be"
     },
     "ap-southeast-5": {
-        "AMI": "ami-0d2aa6b66e53345d1"
+        "AMI": "ami-0784454473e76917a"
     },
     "ap-southeast-6": {
-        "AMI": "ami-0ffdddaf7c6cbb01c"
+        "AMI": "ami-017beedfa5a5fcd10"
     },
     "ap-southeast-7": {
-        "AMI": "ami-01cd5d0f2de117005"
+        "AMI": "ami-0b595cd1038b92abe"
     },
     "ca-central-1": {
-        "AMI": "ami-0e9b6125e224f0559"
+        "AMI": "ami-00ea8b5570deb4189"
     },
     "ca-west-1": {
-        "AMI": "ami-0f04bcfa990afbdd1"
+        "AMI": "ami-020448fba7f6853ef"
     },
     "eu-central-1": {
-        "AMI": "ami-0451e2be16b4ed82d"
+        "AMI": "ami-019b63956e2a74885"
     },
     "eu-central-2": {
-        "AMI": "ami-0c716b7d554e212b0"
+        "AMI": "ami-0dbd5e7d8cfb30e22"
     },
     "eu-north-1": {
-        "AMI": "ami-01e62cc8de1e26c3e"
+        "AMI": "ami-03c978d528a8facb9"
     },
     "eu-south-1": {
-        "AMI": "ami-0d15cfa609d759012"
+        "AMI": "ami-094d8e6fd30faf36f"
     },
     "eu-south-2": {
-        "AMI": "ami-0f5c1105ad2e9f46c"
+        "AMI": "ami-092ca6b7da7389484"
     },
     "eu-west-1": {
-        "AMI": "ami-06c9f03ac2e21d0f6"
+        "AMI": "ami-0c3d6c16a43f48a8f"
     },
     "eu-west-2": {
-        "AMI": "ami-09df054f7d1798f76"
+        "AMI": "ami-0f5b85d52b3563fc4"
     },
     "eu-west-3": {
-        "AMI": "ami-08322a43e180542a2"
+        "AMI": "ami-02a8dd59ba49fcb37"
     },
     "il-central-1": {
-        "AMI": "ami-0c2972948e30419bb"
-    },
-    "me-central-1": {
-        "AMI": "ami-03a80a9d4f25e7354"
-    },
-    "me-south-1": {
-        "AMI": "ami-08b2353814bb9c1f2"
+        "AMI": "ami-056ac155562672928"
     },
     "mx-central-1": {
-        "AMI": "ami-09cbd5e7f8f36d7a4"
+        "AMI": "ami-00ca9b7f25b6591de"
     },
     "sa-east-1": {
-        "AMI": "ami-0e4cb2445d32b0a3c"
+        "AMI": "ami-06d1f0f2ad96d3b99"
     },
     "us-east-1": {
-        "AMI": "ami-08742481d4ceae805"
+        "AMI": "ami-025d5c36daaa8a25c"
     },
     "us-east-2": {
-        "AMI": "ami-0b389b6b5358e5336"
+        "AMI": "ami-0c0f8aa0ed8748b8d"
     },
     "us-west-1": {
-        "AMI": "ami-014b38833899b852f"
+        "AMI": "ami-07c7ef9ee1b766243"
     },
     "us-west-2": {
-        "AMI": "ami-09c7bbac537c82966"
+        "AMI": "ami-038bc9c5f5cfad602"
     }
 }

--- a/tests/RHEL8mapping_arm64.json
+++ b/tests/RHEL8mapping_arm64.json
@@ -1,104 +1,98 @@
 {
     "af-south-1": {
-        "AMI": "ami-05e31482f019e39dd"
+        "AMI": "ami-0d17edc26cde0ee4a"
     },
     "ap-east-1": {
-        "AMI": "ami-06c9c8baf140229bb"
+        "AMI": "ami-0c9956f5a972a949e"
     },
     "ap-east-2": {
-        "AMI": "ami-0381a01cdc9d401ce"
+        "AMI": "ami-0039a436e6ae1658f"
     },
     "ap-northeast-1": {
-        "AMI": "ami-082b7a93c99844a0d"
+        "AMI": "ami-0002a0348ceb51406"
     },
     "ap-northeast-2": {
-        "AMI": "ami-0878fd864607bf1cb"
+        "AMI": "ami-06f299370c2c61c67"
     },
     "ap-northeast-3": {
-        "AMI": "ami-04310d41828f2a46b"
+        "AMI": "ami-0d0c36c3740b89fc4"
     },
     "ap-south-1": {
-        "AMI": "ami-02f4c3a081f9bb8cc"
+        "AMI": "ami-03d96a77329e1489d"
     },
     "ap-south-2": {
-        "AMI": "ami-0607f333fecaea69b"
+        "AMI": "ami-078af330d764c15f7"
     },
     "ap-southeast-1": {
-        "AMI": "ami-061a6ec7c0d606d85"
+        "AMI": "ami-07332dd917829114f"
     },
     "ap-southeast-2": {
-        "AMI": "ami-0cdff69a3e0f233da"
+        "AMI": "ami-091ee13ba1f3be2ce"
     },
     "ap-southeast-3": {
-        "AMI": "ami-0d26465b3ecad6e32"
+        "AMI": "ami-09290f7c1c3dc4d05"
     },
     "ap-southeast-4": {
-        "AMI": "ami-0c8fa8fa20515a303"
+        "AMI": "ami-087a451e8b42a6c91"
     },
     "ap-southeast-5": {
-        "AMI": "ami-0208f4bea54ddcc49"
+        "AMI": "ami-0db12df7c96bd54bb"
     },
     "ap-southeast-6": {
-        "AMI": "ami-09661ee022f84eaf0"
+        "AMI": "ami-06270b88711618177"
     },
     "ap-southeast-7": {
-        "AMI": "ami-04268fa9f17bb08dd"
+        "AMI": "ami-05736c5fe56dfb2e1"
     },
     "ca-central-1": {
-        "AMI": "ami-0f17e7b923130c49b"
+        "AMI": "ami-023adbb1c0bd5e07d"
     },
     "ca-west-1": {
-        "AMI": "ami-010f8664a8c368b8e"
+        "AMI": "ami-070b79af31604007a"
     },
     "eu-central-1": {
-        "AMI": "ami-07eadb9c5ed523f9c"
+        "AMI": "ami-008c050386a8a26bc"
     },
     "eu-central-2": {
-        "AMI": "ami-034b4ac745c376496"
+        "AMI": "ami-00bc52f6831c9f76a"
     },
     "eu-north-1": {
-        "AMI": "ami-0da31f4eae8a2efeb"
+        "AMI": "ami-00ced51a1bad8366e"
     },
     "eu-south-1": {
-        "AMI": "ami-0853c4c808d19b969"
+        "AMI": "ami-0001249b8a927c497"
     },
     "eu-south-2": {
-        "AMI": "ami-01a4e5f69765f79d2"
+        "AMI": "ami-04f7519f41edf1800"
     },
     "eu-west-1": {
-        "AMI": "ami-05ccee0af514adfd8"
+        "AMI": "ami-06c80cafc3e20fe51"
     },
     "eu-west-2": {
-        "AMI": "ami-0137f0a203064c93a"
+        "AMI": "ami-0e0ab0b9d815ed638"
     },
     "eu-west-3": {
-        "AMI": "ami-0b8de7796160a1e2b"
+        "AMI": "ami-084503f85f9e51368"
     },
     "il-central-1": {
-        "AMI": "ami-07189e6e9b489aa64"
-    },
-    "me-central-1": {
-        "AMI": "ami-0ffc9616c3c01be41"
-    },
-    "me-south-1": {
-        "AMI": "ami-063684d35efb478b8"
+        "AMI": "ami-0e8d311372a78e556"
     },
     "mx-central-1": {
-        "AMI": "ami-08fe276dddbb47d26"
+        "AMI": "ami-0b107d4e321b941b4"
     },
     "sa-east-1": {
-        "AMI": "ami-0b07538c49ac97515"
+        "AMI": "ami-06ebf40440f5a5e50"
     },
     "us-east-1": {
-        "AMI": "ami-02510daea86a37361"
+        "AMI": "ami-0180cb1da97123da8"
     },
     "us-east-2": {
-        "AMI": "ami-0665de9aa1b4e9f36"
+        "AMI": "ami-0bba0ad9b27c3ee77"
     },
     "us-west-1": {
-        "AMI": "ami-008ca11034446cb47"
+        "AMI": "ami-05be24e6a439c3725"
     },
     "us-west-2": {
-        "AMI": "ami-00283e224ac7795a0"
+        "AMI": "ami-05f66fbc7697c58d6"
     }
 }

--- a/tests/RHEL9mapping.json
+++ b/tests/RHEL9mapping.json
@@ -1,104 +1,98 @@
 {
     "af-south-1": {
-        "AMI": "ami-081644df9cfdeff00"
+        "AMI": "ami-000a2794600a09ae5"
     },
     "ap-east-1": {
-        "AMI": "ami-028e49842b797b322"
+        "AMI": "ami-0650f470e5a83a2ea"
     },
     "ap-east-2": {
-        "AMI": "ami-08c33ed8afa2d0d73"
+        "AMI": "ami-0592c7e974b43f753"
     },
     "ap-northeast-1": {
-        "AMI": "ami-0e1236ca9acfb8ea5"
+        "AMI": "ami-08188e29bc9c17b3f"
     },
     "ap-northeast-2": {
-        "AMI": "ami-047eacfd454cbcea9"
+        "AMI": "ami-07fe7e90316481e1c"
     },
     "ap-northeast-3": {
-        "AMI": "ami-02a40aa042c9f5b52"
+        "AMI": "ami-0fb6b6c42fbde9c06"
     },
     "ap-south-1": {
-        "AMI": "ami-00889c237bfd9a596"
+        "AMI": "ami-0e040f1c0f9429f44"
     },
     "ap-south-2": {
-        "AMI": "ami-0a0c69e6d5f814294"
+        "AMI": "ami-0aba7af925dcc6262"
     },
     "ap-southeast-1": {
-        "AMI": "ami-02d17d24c27925253"
+        "AMI": "ami-0aa8951e3f7503585"
     },
     "ap-southeast-2": {
-        "AMI": "ami-0e51864a1597399ce"
+        "AMI": "ami-0da899199966fb9c8"
     },
     "ap-southeast-3": {
-        "AMI": "ami-01ac8d42d04d2a75f"
+        "AMI": "ami-0753a80e00c0cf01b"
     },
     "ap-southeast-4": {
-        "AMI": "ami-064a3d09ea4a8efa2"
+        "AMI": "ami-0f77311f4ff525a09"
     },
     "ap-southeast-5": {
-        "AMI": "ami-0a82c8e658e240068"
+        "AMI": "ami-0cf8a3f6102b511d6"
     },
     "ap-southeast-6": {
-        "AMI": "ami-020b2fd5b0ed0e847"
+        "AMI": "ami-02d35126346cd4ae3"
     },
     "ap-southeast-7": {
-        "AMI": "ami-0a120acc19711ce2f"
+        "AMI": "ami-0bba87e3975cb6eda"
     },
     "ca-central-1": {
-        "AMI": "ami-078bf033cabc0cdbe"
+        "AMI": "ami-0179517e3e075cccc"
     },
     "ca-west-1": {
-        "AMI": "ami-01d325631b852da97"
+        "AMI": "ami-00395ece2789d01d1"
     },
     "eu-central-1": {
-        "AMI": "ami-04727bf96678e87dd"
+        "AMI": "ami-01bb2847f0c7f9328"
     },
     "eu-central-2": {
-        "AMI": "ami-059fe580b531b9540"
+        "AMI": "ami-0e4b2ddb79914c06d"
     },
     "eu-north-1": {
-        "AMI": "ami-019d1ff56fa0e30e2"
+        "AMI": "ami-03a6d94a7f454b491"
     },
     "eu-south-1": {
-        "AMI": "ami-08620d878e10ae3a3"
+        "AMI": "ami-0488ad808437fdc8b"
     },
     "eu-south-2": {
-        "AMI": "ami-0e4f51ea846ac3a01"
+        "AMI": "ami-01a7fe2ff2c00d283"
     },
     "eu-west-1": {
-        "AMI": "ami-02acdea491544f61e"
+        "AMI": "ami-02de29b5355f1979b"
     },
     "eu-west-2": {
-        "AMI": "ami-06a1060bab1fa5fea"
+        "AMI": "ami-0d3e6a826bacdac20"
     },
     "eu-west-3": {
-        "AMI": "ami-097e71be7d8dcb5d9"
+        "AMI": "ami-016f387feabe26f36"
     },
     "il-central-1": {
-        "AMI": "ami-0506b7aa8b16b828a"
-    },
-    "me-central-1": {
-        "AMI": "ami-010f1df66da7435b8"
-    },
-    "me-south-1": {
-        "AMI": "ami-0c78b982fe7a3812e"
+        "AMI": "ami-09fc0b9aca7c32a35"
     },
     "mx-central-1": {
-        "AMI": "ami-0a8c9768036f4dd1e"
+        "AMI": "ami-0ed5e8e4a8cd6dc98"
     },
     "sa-east-1": {
-        "AMI": "ami-07e18f0d755f37a73"
+        "AMI": "ami-09369754b78a4bee4"
     },
     "us-east-1": {
-        "AMI": "ami-0e6c4e94540d22db8"
+        "AMI": "ami-07dff10dc7d29a0bf"
     },
     "us-east-2": {
-        "AMI": "ami-03b7743353af39451"
+        "AMI": "ami-0d517450f5161cb97"
     },
     "us-west-1": {
-        "AMI": "ami-02c30de1c5c8e752e"
+        "AMI": "ami-01414e315eb01420e"
     },
     "us-west-2": {
-        "AMI": "ami-009958be1d9580885"
+        "AMI": "ami-0ec4ef7e785715fbe"
     }
 }

--- a/tests/RHEL9mapping_arm64.json
+++ b/tests/RHEL9mapping_arm64.json
@@ -1,104 +1,98 @@
 {
     "af-south-1": {
-        "AMI": "ami-08329033c4e6e20f7"
+        "AMI": "ami-05510f6f414beaa4d"
     },
     "ap-east-1": {
-        "AMI": "ami-07df9cae82a1f4a5a"
+        "AMI": "ami-0c86768bd142bda4b"
     },
     "ap-east-2": {
-        "AMI": "ami-0d9ca2a839ca6b6f5"
+        "AMI": "ami-0a34d447d4f54c03d"
     },
     "ap-northeast-1": {
-        "AMI": "ami-0d3a76a737afd2ec3"
+        "AMI": "ami-02f3e24095f235ee6"
     },
     "ap-northeast-2": {
-        "AMI": "ami-050ddc30c40e54b9f"
+        "AMI": "ami-07ee024b47812c284"
     },
     "ap-northeast-3": {
-        "AMI": "ami-0651f38c6384e1b35"
+        "AMI": "ami-040f8a5740ba3a3b5"
     },
     "ap-south-1": {
-        "AMI": "ami-0c00f41282a26551a"
+        "AMI": "ami-0d551a0aaa3636250"
     },
     "ap-south-2": {
-        "AMI": "ami-091452c43576afd84"
+        "AMI": "ami-02f324006f773877a"
     },
     "ap-southeast-1": {
-        "AMI": "ami-0f4939f909704f94c"
+        "AMI": "ami-0983f4136d316ae12"
     },
     "ap-southeast-2": {
-        "AMI": "ami-0d5630bbe30141f88"
+        "AMI": "ami-038f79d8998cfd0f0"
     },
     "ap-southeast-3": {
-        "AMI": "ami-096c2a892bc54945a"
+        "AMI": "ami-0342de81623e07502"
     },
     "ap-southeast-4": {
-        "AMI": "ami-096af4e2b7d0fabed"
+        "AMI": "ami-046d3ff789fd7e49e"
     },
     "ap-southeast-5": {
-        "AMI": "ami-04faf51d6164cf107"
+        "AMI": "ami-0c60e07aba42c4798"
     },
     "ap-southeast-6": {
-        "AMI": "ami-0cec247a7c234d0bb"
+        "AMI": "ami-06e398dc3efc0c9f1"
     },
     "ap-southeast-7": {
-        "AMI": "ami-09883f902d773e75f"
+        "AMI": "ami-023ba6705be50c03e"
     },
     "ca-central-1": {
-        "AMI": "ami-0fdd94c1a57e72e71"
+        "AMI": "ami-095cf32758e585241"
     },
     "ca-west-1": {
-        "AMI": "ami-0a445d9bc658a4df4"
+        "AMI": "ami-06ca68f100e44f96a"
     },
     "eu-central-1": {
-        "AMI": "ami-0d889d06de8e1900b"
+        "AMI": "ami-0bffab8464771337e"
     },
     "eu-central-2": {
-        "AMI": "ami-017f793e8de0a0385"
+        "AMI": "ami-004b04f42d82efb4f"
     },
     "eu-north-1": {
-        "AMI": "ami-0b07f80bea042bc1d"
+        "AMI": "ami-004934534fca1a7e4"
     },
     "eu-south-1": {
-        "AMI": "ami-0fc3bd8a85d0e4bfb"
+        "AMI": "ami-05aee0f6e709c28fc"
     },
     "eu-south-2": {
-        "AMI": "ami-00b9657235241f596"
+        "AMI": "ami-06c7efcd50fcf38f0"
     },
     "eu-west-1": {
-        "AMI": "ami-07a1f0e7c21d60de2"
+        "AMI": "ami-09709040748714d5d"
     },
     "eu-west-2": {
-        "AMI": "ami-0ce2bc1f180c6b740"
+        "AMI": "ami-0cb54ce751aa6f2ce"
     },
     "eu-west-3": {
-        "AMI": "ami-046dc2ab06ebb94bb"
+        "AMI": "ami-05f9f6fe073ee7e3c"
     },
     "il-central-1": {
-        "AMI": "ami-08fb692d7fd7e1d0c"
-    },
-    "me-central-1": {
-        "AMI": "ami-06e2361dc1dd25620"
-    },
-    "me-south-1": {
-        "AMI": "ami-09c4928e68296da97"
+        "AMI": "ami-01415f5d636d627cc"
     },
     "mx-central-1": {
-        "AMI": "ami-038b29a6ee30863a1"
+        "AMI": "ami-0b0615707456a37f6"
     },
     "sa-east-1": {
-        "AMI": "ami-09addd642f665382f"
+        "AMI": "ami-0980f3c6c63cf6c76"
     },
     "us-east-1": {
-        "AMI": "ami-0ece568c0604ab3aa"
+        "AMI": "ami-04f87e17cd31c70e6"
     },
     "us-east-2": {
-        "AMI": "ami-07b7a8f2461cffa17"
+        "AMI": "ami-09e1df145cc362cdd"
     },
     "us-west-1": {
-        "AMI": "ami-063ae4daa11d4120d"
+        "AMI": "ami-044dac0241b598d66"
     },
     "us-west-2": {
-        "AMI": "ami-044f2ab006dc9b23a"
+        "AMI": "ami-07decf2e89e3da735"
     }
 }

--- a/tests/rhc/main.yml
+++ b/tests/rhc/main.yml
@@ -47,7 +47,7 @@
         assert:
           that:
             - "'Connected to Red Hat Subscription Management' in client_status_3.stdout"
-            - "'Connected to Red Hat Insights' in client_status_3.stdout"
+            - "'Connected to Red Hat Lightspeed' in client_status_3.stdout"
             - "'The yggdrasil service is active' in client_status_3.stdout"
           success_msg: OK
           fail_msg: "{{ client_status_3.stdout_lines }}"


### PR DESCRIPTION
… to match 10.2

## Summary by Sourcery

Refresh test AMI mappings and align rhc status test expectations with current output.

Bug Fixes:
- Update rhc status test to expect the 'Connected to Red Hat Lightspeed' message instead of the deprecated Red Hat Insights string.

Tests:
- Refresh AMI ID mapping JSONs for RHEL 8, 9, and 10 across x86_64 and arm64 test fixtures to use current images.