### PR TITLE
check for HTTP code 403 when using an unauthorized host

### DIFF
--- a/tests/client/main.yml
+++ b/tests/client/main.yml
@@ -44,7 +44,7 @@
 
   - name: check if connection to an unauthorized remote host through the proxy is denied
     vars:
-      curl_error: "{{ 'Received HTTP code 403 from proxy after CONNECT' if ansible_distribution_major_version|int <= 9 else 'CONNECT tunnel failed, response 403' }}"
+      curl_error: "{{ 'Received HTTP code ' ~ expected_proxy_deny_code | string ~ ' from proxy after CONNECT' if ansible_distribution_major_version|int <= 9 else 'CONNECT tunnel failed, response ' ~ expected_proxy_deny_code | string }}"
     command: "curl -L -x http://{{ server }}:3128 https://{{ test_bad_host }}/"
     register: curl_proxy_bad_host
     changed_when: false

--- a/tests/client/main.yml
+++ b/tests/client/main.yml
@@ -44,7 +44,7 @@
 
   - name: check if connection to an unauthorized remote host through the proxy is denied
     vars:
-      curl_error: "{{ 'Received HTTP code 404 from proxy after CONNECT' if ansible_distribution_major_version|int <= 9 else 'CONNECT tunnel failed, response 404' }}"
+      curl_error: "{{ 'Received HTTP code 403 from proxy after CONNECT' if ansible_distribution_major_version|int <= 9 else 'CONNECT tunnel failed, response 403' }}"
     command: "curl -L -x http://{{ server }}:3128 https://{{ test_bad_host }}/"
     register: curl_proxy_bad_host
     changed_when: false

--- a/tests/group_vars/all.yml
+++ b/tests/group_vars/all.yml
@@ -18,6 +18,7 @@ local_user: rhproxy
 command: rhproxy
 test_good_host: mirrors.fedoraproject.org
 test_bad_host: www.fi.muni.cz
+expected_proxy_deny_code: 403
 test_rhsm_package: tree
 test_epel_package: screen
 test_3rd_party_repo:


### PR DESCRIPTION
When rhproxy used nginx as the proxy, the HTTP response code used to be 404 for hosts not on any allow lists, but it's 403 now that rhproxy has started using squid. The test suite must be updated for this change.

## Summary by Sourcery

Tests:
- Adjust the curl error message assertion in the client test to expect HTTP 403 responses for unauthorized proxy connections across supported OS versions.