### PR TITLE
Bumping rhproxy to 1.5.17

### DIFF
--- a/env/epel.servers
+++ b/env/epel.servers
@@ -1,6 +1,6 @@
 # Dnf/Yum EPEL Servers
-# Updated:        2026-06-15
-# Count:          238
+# Updated:        2026-07-01
+# Count:          235
 # Versions:       4, 5, 6, 7, 8, 9, 10
 # Architectures:  aarch64, armhfp, i386, ppc64, ppc64le, s390x, x86_64
 #
@@ -23,7 +23,6 @@ d2lzkl7pfhq30w.cloudfront.net
 de.mirrors.cicku.me
 dfw.mirror.rackspace.com
 distrohub.kyiv.ua
-divergentnetworks.mm.fcix.net
 dl.fedoraproject.org
 epel.grena.ge
 epel.hysing.is
@@ -64,7 +63,6 @@ ftp.arnes.si
 ftp.bme.hu
 ftp.cica.es
 ftp.fau.de
-ftp.kaist.ac.kr
 ftp.linux.edu.lv
 ftp.nsc.ru
 ftp.rediris.es
@@ -105,7 +103,6 @@ mirror.cedia.org.ec
 mirror.centos.ikoula.com
 mirror.cherryservers.com
 mirror.citrahost.com
-mirror.cogentco.com
 mirror.compevo.com
 mirror.cov.ukservers.com
 mirror.cpsc.ucalgary.ca
@@ -116,6 +113,7 @@ mirror.dal.nexril.net
 mirror.de.leaseweb.net
 mirror.digitalnova.at
 mirror.dogado.de
+mirror.dsp-lab.space
 mirror.dst.ca
 mirror.efect.ro
 mirror.etf.bg.ac.rs
@@ -127,7 +125,6 @@ mirror.fmt-2.serverforge.org
 mirror.freedif.org
 mirror.freethought-internet.co.uk
 mirror.grid.uchicago.edu
-mirror.hemino.net
 mirror.hnd.cl
 mirror.host.ag
 mirror.hoster.kz

--- a/rhproxy.spec
+++ b/rhproxy.spec
@@ -1,5 +1,5 @@
-%global rpm_version 1.5.16
-%global engine_version 1.5.13
+%global rpm_version 1.5.17
+%global engine_version 1.5.14
 
 Name:           rhproxy
 Version:        %{rpm_version}
@@ -53,6 +53,9 @@ sed -i 's/{{RHPROXY_ENGINE_RELEASE_TAG}}/%{engine_version}/' %{buildroot}/%{_dat
 %{_datadir}/%{name}/download/bin/configure-client.sh.template
 
 %changelog
+* Wed Jul 01 2026 Alberto Bellotti <abellott@redhat.com> - 1.5.17
+- Now pulling the rhproxy-engine container image 1.5.14 from registry.redhat.io
+
 * Wed Jun 03 2026 Alberto Bellotti <abellott@redhat.com> - 1.5.16
 - Now pulling the rhproxy-engine container image 1.5.13 from registry.redhat.io
 


### PR DESCRIPTION
Bumping rhproxy RPM to version 1.5.17 to pull in rhproxy-engine container image 1.5.14 from registry.redhat.io.

Related: IPP-75

## Summary by Sourcery

Build:
- Update rhproxy.spec to use RPM version 1.5.17 and rhproxy-engine container image version 1.5.14 from registry.redhat.io.